### PR TITLE
Add debug option to allow retaking videos for past days

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/SettingsDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/SettingsDao.kt
@@ -5,6 +5,7 @@ import android.util.Size
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -35,6 +36,9 @@ class SettingsDao(
 
     /** The selected duration of each video in seconds */
     private val videoDurationMillisKey = longPreferencesKey("videoDurationMillis")
+
+    /** Debug setting: whether the user is allowed to retake the video for a past day */
+    private val debugAllowRetakeForPastDaysKey = booleanPreferencesKey("debugAllowRetakeForPastDays")
 
     suspend fun setResolution(resolution: Size) {
         val components = listOf(resolution.width, resolution.height)
@@ -94,6 +98,18 @@ class SettingsDao(
     suspend fun getVideoDuration(): Duration? {
         val millis = getPrefs()[videoDurationMillisKey] ?: return null
         return millis.milliseconds
+    }
+
+    suspend fun setDebugAllowRetakeForPastDays(allow: Boolean) {
+        updatePrefs {
+            set(debugAllowRetakeForPastDaysKey, allow)
+        }
+    }
+
+    fun getDebugAllowRetakeForPastDaysFlow(): Flow<Boolean> {
+        return context.dataStore.data.map { prefs ->
+            prefs[debugAllowRetakeForPastDaysKey] ?: false
+        }
     }
 
     private suspend fun getPrefs() = context.dataStore.data.first()

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -144,6 +144,7 @@ object KoinModule {
                 calendarRepository = get(),
                 videoResolutionRepository = get(),
                 videosDao = get(),
+                settingsDao = get(),
             )
         }
         viewModel {
@@ -160,6 +161,7 @@ object KoinModule {
         viewModel {
             DebugViewModel(
                 mockDataRepository = get(),
+                settingsDao = get(),
             )
         }
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/CalendarPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/CalendarPage.kt
@@ -2,11 +2,12 @@ package com.lukeneedham.videodiary.ui.feature.calendar
 
 import androidx.compose.runtime.Composable
 import com.lukeneedham.videodiary.domain.model.ShareRequest
+import java.time.LocalDate
 
 @Composable
 fun CalendarPage(
     viewModel: CalendarViewModel,
-    onRecordTodayVideoClick: () -> Unit,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     exportFullVideo: () -> Unit,
     onDebugClick: () -> Unit,
     share: (ShareRequest) -> Unit,
@@ -15,7 +16,8 @@ fun CalendarPage(
         days = viewModel.days,
         videoAspectRatio = viewModel.videoAspectRatio,
         currentDayIndex = viewModel.currentDayIndex,
-        onRecordTodayVideoClick = onRecordTodayVideoClick,
+        allowRetakeForPastDays = viewModel.allowRetakeForPastDays,
+        onRecordVideoClick = onRecordVideoClick,
         onDeleteTodayVideoClick = viewModel::deleteTodayVideo,
         goToDate = viewModel::goToDate,
         setCurrentDayIndex = viewModel::setCurrentDay,

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/CalendarPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/CalendarPageContent.kt
@@ -30,7 +30,8 @@ fun CalendarPageContent(
     days: List<Day>,
     videoAspectRatio: Float?,
     currentDayIndex: Int,
-    onRecordTodayVideoClick: () -> Unit,
+    allowRetakeForPastDays: Boolean,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     onDeleteTodayVideoClick: () -> Unit,
     goToDate: (date: LocalDate) -> Unit,
     setCurrentDayIndex: (Int) -> Unit,
@@ -55,7 +56,8 @@ fun CalendarPageContent(
             CalendarScroller(
                 days = days,
                 videoAspectRatio = videoAspectRatio,
-                onRecordTodayVideoClick = onRecordTodayVideoClick,
+                allowRetakeForPastDays = allowRetakeForPastDays,
+                onRecordVideoClick = onRecordVideoClick,
                 onDeleteTodayVideoClick = onDeleteClick,
                 openDayPicker = {
                     showDayPickerDialog = true
@@ -112,7 +114,8 @@ private fun Preview(
             days = MockDataCalendar.days,
             videoAspectRatio = MockDataCalendar.videoAspectRatio,
             currentDayIndex = currentDayIndex,
-            onRecordTodayVideoClick = {},
+            allowRetakeForPastDays = false,
+            onRecordVideoClick = {},
             onDeleteTodayVideoClick = {},
             goToDate = {},
             setCurrentDayIndex = {},

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/CalendarViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.lukeneedham.videodiary.data.persistence.SettingsDao
 import com.lukeneedham.videodiary.data.persistence.VideosDao
 import com.lukeneedham.videodiary.data.repository.CalendarRepository
 import com.lukeneedham.videodiary.data.repository.VideoResolutionRepository
@@ -19,6 +20,7 @@ class CalendarViewModel(
     private val calendarRepository: CalendarRepository,
     private val videoResolutionRepository: VideoResolutionRepository,
     private val videosDao: VideosDao,
+    private val settingsDao: SettingsDao,
 ) : ViewModel() {
 
     /**
@@ -40,7 +42,15 @@ class CalendarViewModel(
     var currentDayIndex by mutableIntStateOf(0)
         private set
 
+    var allowRetakeForPastDays by mutableStateOf(false)
+        private set
+
     init {
+        viewModelScope.launch {
+            settingsDao.getDebugAllowRetakeForPastDaysFlow().collect { allow ->
+                allowRetakeForPastDays = allow
+            }
+        }
         viewModelScope.launch {
             calendarRepository.allDays.collect { newDays ->
                 val oldDays = days

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarScroller.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarScroller.kt
@@ -20,13 +20,15 @@ import com.lukeneedham.videodiary.ui.feature.calendar.component.portrait.Calenda
 import com.lukeneedham.videodiary.ui.feature.calendar.component.portrait.CalendarScrollerPortrait
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.rememberVideoPlayerController
+import java.time.LocalDate
 
 @Composable
 fun CalendarScroller(
     days: List<Day>,
     currentDayIndex: Int,
     videoAspectRatio: Float,
-    onRecordTodayVideoClick: () -> Unit,
+    allowRetakeForPastDays: Boolean,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     onDeleteTodayVideoClick: () -> Unit,
     openDayPicker: () -> Unit,
     exportFullVideo: () -> Unit,
@@ -85,7 +87,8 @@ fun CalendarScroller(
                     CalendarDayPortrait(
                         day = currentDay,
                         videoAspectRatio = videoAspectRatio,
-                        onRecordTodayVideoClick = onRecordTodayVideoClick,
+                        allowRetakeForPastDays = allowRetakeForPastDays,
+                        onRecordVideoClick = onRecordVideoClick,
                         onDeleteTodayVideoClick = onDeleteTodayVideoClick,
                         videoPlayerController = videoPlayerController,
                         share = share,
@@ -105,7 +108,8 @@ fun CalendarScroller(
                     CalendarDayLandscape(
                         day = currentDay,
                         videoAspectRatio = videoAspectRatio,
-                        onRecordTodayVideoClick = onRecordTodayVideoClick,
+                        allowRetakeForPastDays = allowRetakeForPastDays,
+                        onRecordVideoClick = onRecordVideoClick,
                         onDeleteTodayVideoClick = onDeleteTodayVideoClick,
                         videoPlayerController = videoPlayerController,
                         share = share,
@@ -122,7 +126,8 @@ internal fun PreviewCalendarScroller() {
     CalendarScroller(
         days = MockDataCalendar.days,
         videoAspectRatio = 1f,
-        onRecordTodayVideoClick = {},
+        allowRetakeForPastDays = false,
+        onRecordVideoClick = {},
         onDeleteTodayVideoClick = {},
         openDayPicker = {},
         setCurrentDayIndex = {},

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/actionbar/CalendarDayActionBarContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/actionbar/CalendarDayActionBarContent.kt
@@ -9,12 +9,14 @@ import com.lukeneedham.videodiary.domain.model.ShareRequest
 import com.lukeneedham.videodiary.domain.util.date.StandardDateTimeFormatter
 import com.lukeneedham.videodiary.ui.feature.calendar.MockDataCalendar
 import com.lukeneedham.videodiary.ui.feature.common.Button
+import java.time.LocalDate
 
 /** The content of the action bar, which gets splatted into a layout that the parent decides */
 @Composable
 fun CalendarDayActionBarContent(
     day: Day,
-    onRecordTodayVideoClick: () -> Unit,
+    allowRetakeForPastDays: Boolean,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     onDeleteTodayVideoClick: () -> Unit,
     share: (ShareRequest) -> Unit,
     buttonModifier: Modifier,
@@ -39,14 +41,14 @@ fun CalendarDayActionBarContent(
         if (isToday) {
             ActionButton(
                 text = "Record",
-                onClick = onRecordTodayVideoClick,
+                onClick = { onRecordVideoClick(date) },
             )
         }
     } else {
-        if (isToday) {
+        if (isToday || allowRetakeForPastDays) {
             ActionButton(
                 text = "Retake",
-                onClick = onRecordTodayVideoClick,
+                onClick = { onRecordVideoClick(date) },
             )
         }
 
@@ -79,7 +81,8 @@ internal fun PreviewCalendarDayActionBar() {
     Row {
         CalendarDayActionBarContent(
             day = MockDataCalendar.dayWithVideo,
-            onRecordTodayVideoClick = {},
+            allowRetakeForPastDays = false,
+            onRecordVideoClick = {},
             onDeleteTodayVideoClick = {},
             share = {},
             buttonModifier = Modifier.weight(1f),

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCard.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCard.kt
@@ -10,13 +10,14 @@ import com.lukeneedham.videodiary.domain.model.Day
 import com.lukeneedham.videodiary.ui.feature.calendar.MockDataCalendar
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.rememberVideoPlayerController
+import java.time.LocalDate
 
 @Composable
 fun CalendarDayCard(
     day: Day,
     videoAspectRatio: Float,
     videoPlayerController: VideoPlayerController,
-    onRecordTodayVideoClick: () -> Unit,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -29,7 +30,7 @@ fun CalendarDayCard(
             if (isToday) {
                 CalendarDayCardTodayMissing(
                     modifier = Modifier.clickable {
-                        onRecordTodayVideoClick()
+                        onRecordVideoClick(day.date)
                     }
                 )
             } else {
@@ -51,7 +52,7 @@ internal fun PreviewCalendarDayCard() {
     CalendarDayCard(
         day = MockDataCalendar.dayWithVideo,
         videoAspectRatio = 1f,
-        onRecordTodayVideoClick = {},
+        onRecordVideoClick = {},
         videoPlayerController = rememberVideoPlayerController(),
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/landscape/CalendarDayLandscape.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/landscape/CalendarDayLandscape.kt
@@ -20,13 +20,15 @@ import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoControlActi
 import com.lukeneedham.videodiary.ui.feature.calendar.component.day.card.CalendarDayCard
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.rememberVideoPlayerController
+import java.time.LocalDate
 
 @Composable
 fun CalendarDayLandscape(
     day: Day,
     videoAspectRatio: Float,
     videoPlayerController: VideoPlayerController,
-    onRecordTodayVideoClick: () -> Unit,
+    allowRetakeForPastDays: Boolean,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     onDeleteTodayVideoClick: () -> Unit,
     share: (ShareRequest) -> Unit,
     modifier: Modifier = Modifier
@@ -42,7 +44,7 @@ fun CalendarDayLandscape(
             CalendarDayCard(
                 day = day,
                 videoAspectRatio = videoAspectRatio,
-                onRecordTodayVideoClick = onRecordTodayVideoClick,
+                onRecordVideoClick = onRecordVideoClick,
                 videoPlayerController = videoPlayerController,
                 modifier = Modifier
                     .weight(1f)
@@ -66,7 +68,8 @@ fun CalendarDayLandscape(
 
             CalendarDayActionBarContent(
                 day = day,
-                onRecordTodayVideoClick = onRecordTodayVideoClick,
+                allowRetakeForPastDays = allowRetakeForPastDays,
+                onRecordVideoClick = onRecordVideoClick,
                 onDeleteTodayVideoClick = onDeleteTodayVideoClick,
                 share = share,
                 buttonModifier = Modifier
@@ -81,7 +84,8 @@ fun CalendarDayLandscape(
 internal fun PreviewCalendarDayLandscape() {
     CalendarDayLandscape(
         day = MockDataCalendar.dayWithVideo,
-        onRecordTodayVideoClick = {},
+        allowRetakeForPastDays = false,
+        onRecordVideoClick = {},
         videoAspectRatio = 1f,
         videoPlayerController = rememberVideoPlayerController(),
         onDeleteTodayVideoClick = {},

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/portrait/CalendarDayPortrait.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/portrait/CalendarDayPortrait.kt
@@ -19,13 +19,15 @@ import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoControlActi
 import com.lukeneedham.videodiary.ui.feature.calendar.component.day.card.CalendarDayCard
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.rememberVideoPlayerController
+import java.time.LocalDate
 
 @Composable
 fun CalendarDayPortrait(
     day: Day,
     videoAspectRatio: Float,
     videoPlayerController: VideoPlayerController,
-    onRecordTodayVideoClick: () -> Unit,
+    allowRetakeForPastDays: Boolean,
+    onRecordVideoClick: (date: LocalDate) -> Unit,
     onDeleteTodayVideoClick: () -> Unit,
     share: (ShareRequest) -> Unit,
     modifier: Modifier = Modifier
@@ -36,7 +38,7 @@ fun CalendarDayPortrait(
         CalendarDayCard(
             day = day,
             videoAspectRatio = videoAspectRatio,
-            onRecordTodayVideoClick = onRecordTodayVideoClick,
+            onRecordVideoClick = onRecordVideoClick,
             videoPlayerController = videoPlayerController,
             modifier = Modifier
                 .weight(1f)
@@ -58,7 +60,8 @@ fun CalendarDayPortrait(
         ) {
             CalendarDayActionBarContent(
                 day = day,
-                onRecordTodayVideoClick = onRecordTodayVideoClick,
+                allowRetakeForPastDays = allowRetakeForPastDays,
+                onRecordVideoClick = onRecordVideoClick,
                 onDeleteTodayVideoClick = onDeleteTodayVideoClick,
                 share = share,
                 buttonModifier = Modifier
@@ -74,7 +77,8 @@ fun CalendarDayPortrait(
 internal fun PreviewCalendarDayPortrait() {
     CalendarDayPortrait(
         day = MockDataCalendar.dayWithVideo,
-        onRecordTodayVideoClick = {},
+        allowRetakeForPastDays = false,
+        onRecordVideoClick = {},
         videoAspectRatio = 1f,
         videoPlayerController = rememberVideoPlayerController(),
         onDeleteTodayVideoClick = {},

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPage.kt
@@ -1,6 +1,8 @@
 package com.lukeneedham.videodiary.ui.feature.debug
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 
 @Composable
 fun DebugPage(
@@ -8,8 +10,12 @@ fun DebugPage(
     canGoBack: Boolean,
     onBack: () -> Unit,
 ) {
+    val allowRetakeForPastDays by viewModel.allowRetakeForPastDays.collectAsState()
+
     DebugPageContent(
         onFillWithMockDataClick = viewModel::fillWithMockData,
+        allowRetakeForPastDays = allowRetakeForPastDays,
+        onAllowRetakeForPastDaysChange = viewModel::setAllowRetakeForPastDays,
         canGoBack = canGoBack,
         onBack = onBack,
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPageContent.kt
@@ -2,13 +2,17 @@ package com.lukeneedham.videodiary.ui.feature.debug
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,6 +23,8 @@ import com.lukeneedham.videodiary.ui.theme.Typography
 @Composable
 fun DebugPageContent(
     onFillWithMockDataClick: () -> Unit,
+    allowRetakeForPastDays: Boolean,
+    onAllowRetakeForPastDaysChange: (Boolean) -> Unit,
     canGoBack: Boolean,
     onBack: () -> Unit,
 ) {
@@ -47,6 +53,14 @@ fun DebugPageContent(
                 description = "Overwrites all diary data with a random mix of mock videos, " +
                     "spanning the last 5 weeks",
                 onClick = onFillWithMockDataClick,
+            )
+
+            DebugCheckboxOption(
+                title = "Allow retake for past days",
+                description = "Shows the Retake button for past days, allowing the video " +
+                    "for that day to be re-recorded. Normally only today's video can be retaken",
+                checked = allowRetakeForPastDays,
+                onCheckedChange = onAllowRetakeForPastDaysChange,
             )
         }
     }
@@ -78,11 +92,48 @@ private fun DebugOption(
     }
 }
 
+@Composable
+private fun DebugCheckboxOption(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) }
+            .padding(vertical = 10.dp)
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column {
+            Text(
+                text = title,
+                color = Color.Black,
+                fontSize = Typography.Size.small,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = description,
+                color = Color.Black,
+                fontSize = Typography.Size.extraSmall,
+            )
+        }
+    }
+}
+
 @Preview
 @Composable
 internal fun PreviewDebugPageContent() {
     DebugPageContent(
         onFillWithMockDataClick = {},
+        allowRetakeForPastDays = false,
+        onAllowRetakeForPastDaysChange = {},
         canGoBack = true,
         onBack = {},
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugViewModel.kt
@@ -1,12 +1,28 @@
 package com.lukeneedham.videodiary.ui.feature.debug
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lukeneedham.videodiary.data.persistence.SettingsDao
 import com.lukeneedham.videodiary.data.repository.MockDataRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 class DebugViewModel(
     private val mockDataRepository: MockDataRepository,
+    private val settingsDao: SettingsDao,
 ) : ViewModel() {
+    val allowRetakeForPastDays: StateFlow<Boolean> = settingsDao.getDebugAllowRetakeForPastDaysFlow()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
     fun fillWithMockData() {
         mockDataRepository.fillWithMockData()
+    }
+
+    fun setAllowRetakeForPastDays(allow: Boolean) {
+        viewModelScope.launch {
+            settingsDao.setDebugAllowRetakeForPastDays(allow)
+        }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalPage.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 @Parcelize
 sealed class NormalPage : Parcelable {
     data object Calendar : NormalPage()
-    data object RecordVideo : NormalPage()
+    data class RecordVideo(val date: LocalDate) : NormalPage()
     data class CheckVideo(
         val date: LocalDate,
         val videoContentUri: Uri,

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalRouter.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalRouter.kt
@@ -17,7 +17,6 @@ import dev.olshevski.navigation.reimagined.popUpTo
 import dev.olshevski.navigation.reimagined.rememberNavController
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
-import java.time.LocalDate
 
 @Composable
 fun NormalRouter(
@@ -47,8 +46,8 @@ fun NormalRouter(
         when (page) {
             is NormalPage.Calendar -> CalendarPage(
                 viewModel = koinViewModel(),
-                onRecordTodayVideoClick = {
-                    navigate(NormalPage.RecordVideo)
+                onRecordVideoClick = { date ->
+                    navigate(NormalPage.RecordVideo(date))
                 },
                 exportFullVideo = {
                     navigate(NormalPage.ExportDiaryCreate)
@@ -64,7 +63,7 @@ fun NormalRouter(
                 onRecordingFinished = { videoContentUri ->
                     navigate(
                         NormalPage.CheckVideo(
-                            date = LocalDate.now(),
+                            date = page.date,
                             videoContentUri = videoContentUri,
                         )
                     )


### PR DESCRIPTION
Adds a checkbox on the debug page (off by default) that, when enabled,
shows the Retake button for past days with a recorded video. The
recording flow now carries the day's date through to the check video
screen so the correct day's video is overwritten.