### PR TITLE
Allow recording past days with no video when debug retake setting enabled

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/actionbar/CalendarDayActionBarContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/actionbar/CalendarDayActionBarContent.kt
@@ -38,7 +38,7 @@ fun CalendarDayActionBarContent(
     }
 
     if (video == null) {
-        if (isToday) {
+        if (isToday || allowRetakeForPastDays) {
             ActionButton(
                 text = "Record",
                 onClick = { onRecordVideoClick(date) },

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCard.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCard.kt
@@ -17,6 +17,7 @@ fun CalendarDayCard(
     day: Day,
     videoAspectRatio: Float,
     videoPlayerController: VideoPlayerController,
+    allowRetakeForPastDays: Boolean,
     onRecordVideoClick: (date: LocalDate) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -34,7 +35,13 @@ fun CalendarDayCard(
                     }
                 )
             } else {
-                CalendarDayCardPastMissing()
+                CalendarDayCardPastMissing(
+                    onRecordVideoClick = if (allowRetakeForPastDays) {
+                        { onRecordVideoClick(day.date) }
+                    } else {
+                        null
+                    }
+                )
             }
         } else {
             CalendarDayCardVideo(
@@ -52,6 +59,7 @@ internal fun PreviewCalendarDayCard() {
     CalendarDayCard(
         day = MockDataCalendar.dayWithVideo,
         videoAspectRatio = 1f,
+        allowRetakeForPastDays = false,
         onRecordVideoClick = {},
         videoPlayerController = rememberVideoPlayerController(),
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCardPastMissing.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCardPastMissing.kt
@@ -1,5 +1,6 @@
 package com.lukeneedham.videodiary.ui.feature.calendar.component.day.card
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Text
@@ -10,12 +11,24 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun CalendarDayCardPastMissing() {
+fun CalendarDayCardPastMissing(
+    onRecordVideoClick: (() -> Unit)? = null,
+) {
+    val modifier = if (onRecordVideoClick != null) {
+        Modifier.clickable(onClick = onRecordVideoClick)
+    } else {
+        Modifier
+    }
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize()
     ) {
-        Text(text = "No video for this day! You missed it!", color = Color.Black)
+        val text = if (onRecordVideoClick != null) {
+            "No video for this day! Tap to record one now."
+        } else {
+            "No video for this day! You missed it!"
+        }
+        Text(text = text, color = Color.Black)
     }
 }
 
@@ -23,4 +36,10 @@ fun CalendarDayCardPastMissing() {
 @Composable
 internal fun PreviewCalendarDayMissing() {
     CalendarDayCardPastMissing()
+}
+
+@Preview
+@Composable
+internal fun PreviewCalendarDayMissingRecordable() {
+    CalendarDayCardPastMissing(onRecordVideoClick = {})
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/landscape/CalendarDayLandscape.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/landscape/CalendarDayLandscape.kt
@@ -44,6 +44,7 @@ fun CalendarDayLandscape(
             CalendarDayCard(
                 day = day,
                 videoAspectRatio = videoAspectRatio,
+                allowRetakeForPastDays = allowRetakeForPastDays,
                 onRecordVideoClick = onRecordVideoClick,
                 videoPlayerController = videoPlayerController,
                 modifier = Modifier

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/portrait/CalendarDayPortrait.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/portrait/CalendarDayPortrait.kt
@@ -38,6 +38,7 @@ fun CalendarDayPortrait(
         CalendarDayCard(
             day = day,
             videoAspectRatio = videoAspectRatio,
+            allowRetakeForPastDays = allowRetakeForPastDays,
             onRecordVideoClick = onRecordVideoClick,
             videoPlayerController = videoPlayerController,
             modifier = Modifier


### PR DESCRIPTION
Previously the debug "allow retake for past days" setting only enabled
the Retake button/action for past days that already had a video. Past
days with no video at all showed a non-interactive "missed it" card and
no Record button. Now those days are clickable and show a Record button
when the setting is enabled.