### PR TITLE
Generate and render video thumbnails

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/data/mapper/ThumbnailFileNameMapper.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/mapper/ThumbnailFileNameMapper.kt
@@ -1,0 +1,20 @@
+package com.lukeneedham.videodiary.data.mapper
+
+import java.time.LocalDate
+
+class ThumbnailFileNameMapper {
+    fun dateToName(date: LocalDate): String {
+        val components = listOf(
+            date.year,
+            date.monthValue,
+            date.dayOfMonth,
+        )
+        val name = components.joinToString(separator)
+        return name + extension
+    }
+
+    companion object {
+        private const val separator = "-"
+        private const val extension = ".jpg"
+    }
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -1,0 +1,31 @@
+package com.lukeneedham.videodiary.data.persistence
+
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
+import com.lukeneedham.videodiary.domain.util.logger.Logger
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Extracts the first frame of a video file and saves it as a JPEG thumbnail.
+ */
+class VideoThumbnailExtractor {
+    fun extractFirstFrame(videoFile: File, thumbnailFile: File) {
+        val retriever = MediaMetadataRetriever()
+        try {
+            retriever.setDataSource(videoFile.absolutePath)
+            val frame = retriever.frameAtTime ?: return
+            FileOutputStream(thumbnailFile).use { output ->
+                frame.compress(Bitmap.CompressFormat.JPEG, jpegQuality, output)
+            }
+        } catch (e: Exception) {
+            Logger.error("Error extracting video thumbnail", e)
+        } finally {
+            retriever.release()
+        }
+    }
+
+    companion object {
+        private const val jpegQuality = 90
+    }
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
@@ -3,6 +3,7 @@ package com.lukeneedham.videodiary.data.persistence
 import android.content.Context
 import android.net.Uri
 import android.provider.MediaStore
+import com.lukeneedham.videodiary.data.mapper.ThumbnailFileNameMapper
 import com.lukeneedham.videodiary.data.mapper.VideoFileNameMapper
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,12 +14,13 @@ import java.time.LocalDate
 class VideosDao(
     private val context: Context,
     private val videoFileNameMapper: VideoFileNameMapper,
+    private val thumbnailFileNameMapper: ThumbnailFileNameMapper,
+    private val videoThumbnailExtractor: VideoThumbnailExtractor,
 ) {
     private val videosDir = File(context.filesDir, "videos").apply {
         mkdirs()
     }
 
-    // todo: wire this up to store and use thumbnails
     private val thumbnailsDir = File(context.filesDir, "thumbnails").apply {
         mkdirs()
     }
@@ -31,6 +33,7 @@ class VideosDao(
     fun deleteVideo(date: LocalDate) {
         val file = getVideoFile(date)
         file.delete()
+        getThumbnailFile(date).delete()
         refreshVideosState()
     }
 
@@ -52,6 +55,7 @@ class VideosDao(
                 }
 
                 sourceFile.copyTo(destinationFile)
+                videoThumbnailExtractor.extractFirstFrame(destinationFile, getThumbnailFile(date))
                 refreshVideosState()
             } else {
                 Logger.error("Failed to get video path from content URI")
@@ -83,13 +87,16 @@ class VideosDao(
     }
 
     fun getThumbnailFileIfExists(date: LocalDate): File? {
-        // todo: no thumbnails yet - implement with thumbnailsDir
-        return null
+        val file = getThumbnailFile(date)
+        return if (file.exists()) file else null
     }
 
     private fun getVideoFile(name: String) = File(videosDir, name)
 
     private fun getVideoFileName(date: LocalDate) = videoFileNameMapper.dateToName(date)
+
+    private fun getThumbnailFile(date: LocalDate) =
+        File(thumbnailsDir, thumbnailFileNameMapper.dateToName(date))
 
     /** Should be invoked whenever the persisted video files change in any way */
     private fun refreshVideosState() {

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
@@ -91,6 +91,34 @@ class VideosDao(
         return if (file.exists()) file else null
     }
 
+    /**
+     * Generates thumbnails for any persisted videos that don't yet have one.
+     * Intended to be run once on app startup, to backfill videos that were
+     * saved before thumbnail generation was introduced.
+     */
+    fun generateMissingThumbnails() {
+        val videoFiles = videosDir.listFiles() ?: return
+        var generatedAny = false
+        videoFiles.forEach { videoFile ->
+            val date = try {
+                videoFileNameMapper.nameToDate(videoFile.name)
+            } catch (e: Exception) {
+                Logger.warning("Skipping video with unrecognised file name: ${videoFile.name}", e)
+                return@forEach
+            }
+
+            val thumbnailFile = getThumbnailFile(date)
+            if (!thumbnailFile.exists()) {
+                videoThumbnailExtractor.extractFirstFrame(videoFile, thumbnailFile)
+                generatedAny = true
+            }
+        }
+
+        if (generatedAny) {
+            refreshVideosState()
+        }
+    }
+
     private fun getVideoFile(name: String) = File(videosDir, name)
 
     private fun getVideoFileName(date: LocalDate) = videoFileNameMapper.dateToName(date)

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -2,9 +2,11 @@ package com.lukeneedham.videodiary.di
 
 import android.net.Uri
 import com.lukeneedham.videodiary.data.android.PermissionChecker
+import com.lukeneedham.videodiary.data.mapper.ThumbnailFileNameMapper
 import com.lukeneedham.videodiary.data.mapper.VideoFileNameMapper
 import com.lukeneedham.videodiary.data.persistence.SettingsDao
 import com.lukeneedham.videodiary.data.persistence.VideoExportDao
+import com.lukeneedham.videodiary.data.persistence.VideoThumbnailExtractor
 import com.lukeneedham.videodiary.data.persistence.VideosDao
 import com.lukeneedham.videodiary.data.persistence.export.VideoExporter
 import com.lukeneedham.videodiary.data.repository.CalendarRepository
@@ -55,6 +57,8 @@ object KoinModule {
 
     private fun getData() = module {
         factory { VideoFileNameMapper() }
+        factory { ThumbnailFileNameMapper() }
+        factory { VideoThumbnailExtractor() }
         factory {
             PermissionChecker(
                 context = androidContext(),
@@ -64,6 +68,8 @@ object KoinModule {
             VideosDao(
                 context = androidContext(),
                 videoFileNameMapper = get(),
+                thumbnailFileNameMapper = get(),
+                videoThumbnailExtractor = get(),
             )
         }
         factory {

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -109,6 +109,8 @@ object KoinModule {
             RootViewModel(
                 settingsDao = get(),
                 permissionChecker = get(),
+                videosDao = get(),
+                ioDispatcher = get(KoinQualifier.Dispatcher.io),
             )
         }
         viewModel {

--- a/app/src/main/java/com/lukeneedham/videodiary/domain/model/Day.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/domain/model/Day.kt
@@ -6,8 +6,7 @@ import java.time.LocalDate
 data class Day(
     val date: LocalDate,
     val videoFile: File?,
-    /** todo: use */
-    val thumbnailFile: File?,
+    val thumbnailFile: File? = null,
 ) {
     val today = LocalDate.now()
     val isToday = today == date

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCard.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCard.kt
@@ -45,6 +45,7 @@ fun CalendarDayCard(
         } else {
             CalendarDayCardVideo(
                 video = video,
+                thumbnailFile = day.thumbnailFile,
                 videoAspectRatio = videoAspectRatio,
                 videoPlayerController = videoPlayerController,
             )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCardVideo.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/card/CalendarDayCardVideo.kt
@@ -21,6 +21,7 @@ import java.io.File
 @Composable
 fun CalendarDayCardVideo(
     video: File,
+    thumbnailFile: File?,
     videoAspectRatio: Float,
     videoPlayerController: VideoPlayerController,
 ) {
@@ -31,6 +32,7 @@ fun CalendarDayCardVideo(
     ) {
         VideoPlayer(
             video = Video.PersistedFile(video),
+            thumbnailFile = thumbnailFile,
             aspectRatio = videoAspectRatio,
             controller = videoPlayerController,
         )
@@ -42,6 +44,7 @@ fun CalendarDayCardVideo(
 internal fun PreviewCalendarDayCardVideo() {
     CalendarDayCardVideo(
         video = MockDataCalendar.file,
+        thumbnailFile = null,
         videoAspectRatio = 1f,
         videoPlayerController = rememberVideoPlayerController(),
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayer.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayer.kt
@@ -1,20 +1,27 @@
 package com.lukeneedham.videodiary.ui.feature.common.videoplayer
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.lukeneedham.videodiary.R
 import com.lukeneedham.videodiary.domain.model.Video
-import com.lukeneedham.videodiary.domain.util.logger.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -25,6 +32,7 @@ fun VideoPlayer(
     video: Video,
     aspectRatio: Float,
     controller: VideoPlayerController,
+    thumbnailFile: File? = null,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -48,12 +56,20 @@ fun VideoPlayer(
                     video = video,
                     controller = controller,
                 )
-            } else {
-                // todo: render the thumbnail for this video,
-                //  which should be the first frame of the video.
-                //  Really this should be saved on disk next to the video,
-                //  so we can load it really quickly.
-                Text(text = "thumbnail", color = Color.White)
+            } else if (thumbnailFile != null) {
+                val thumbnail by produceState<Bitmap?>(initialValue = null, thumbnailFile) {
+                    value = withContext(Dispatchers.IO) {
+                        BitmapFactory.decodeFile(thumbnailFile.absolutePath)
+                    }
+                }
+                thumbnail?.let { bitmap ->
+                    Image(
+                        bitmap = bitmap.asImageBitmap(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
     }
@@ -64,6 +80,7 @@ fun VideoPlayer(
 internal fun PreviewVideoPlayer() {
     VideoPlayer(
         video = Video.PersistedFile(File("")),
+        thumbnailFile = null,
         aspectRatio = 1f,
         controller = rememberVideoPlayerController(),
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/root/RootViewModel.kt
@@ -8,12 +8,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lukeneedham.videodiary.data.android.PermissionChecker
 import com.lukeneedham.videodiary.data.persistence.SettingsDao
+import com.lukeneedham.videodiary.data.persistence.VideosDao
 import com.lukeneedham.videodiary.ui.permissions.RequiredPermissions
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class RootViewModel(
     private val settingsDao: SettingsDao,
     private val permissionChecker: PermissionChecker,
+    private val videosDao: VideosDao,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private var isMissingPermissions: Boolean? by mutableStateOf(null)
     private var hasSetupCompleted: Boolean? by mutableStateOf(null)
@@ -51,6 +56,11 @@ class RootViewModel(
                 } else {
                     RootOrientationState.Ready(orientation)
                 }
+            }
+        }
+        viewModelScope.launch {
+            withContext(ioDispatcher) {
+                videosDao.generateMissingThumbnails()
             }
         }
     }


### PR DESCRIPTION
Extracts the first frame of each saved video as a JPEG thumbnail
stored alongside the video, and renders it in the calendar scroller
for non-active pages before video playback starts.

https://claude.ai/code/session_011CwqduuZ2ektRU6UzdWSN5