### PR TITLE
Fix flicker when scrolling to a video by keeping thumbnail until first frame

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayer.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayer.kt
@@ -56,22 +56,36 @@ fun VideoPlayer(
                     video = video,
                     controller = controller,
                 )
-            } else if (thumbnailFile != null) {
-                val thumbnail by produceState<Bitmap?>(initialValue = null, thumbnailFile) {
-                    value = withContext(Dispatchers.IO) {
-                        BitmapFactory.decodeFile(thumbnailFile.absolutePath)
-                    }
+
+                // Keep the thumbnail on top until the player has rendered its first
+                // frame, so the player's surface (briefly black while preparing)
+                // is never shown to the user.
+                if (!controller.hasRenderedFirstFrame) {
+                    VideoThumbnail(thumbnailFile)
                 }
-                thumbnail?.let { bitmap ->
-                    Image(
-                        bitmap = bitmap.asImageBitmap(),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
+            } else {
+                VideoThumbnail(thumbnailFile)
             }
         }
+    }
+}
+
+@Composable
+private fun VideoThumbnail(thumbnailFile: File?) {
+    if (thumbnailFile == null) return
+
+    val thumbnail by produceState<Bitmap?>(initialValue = null, thumbnailFile) {
+        value = withContext(Dispatchers.IO) {
+            BitmapFactory.decodeFile(thumbnailFile.absolutePath)
+        }
+    }
+    thumbnail?.let { bitmap ->
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
     }
 }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayer.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayer.kt
@@ -51,20 +51,16 @@ fun VideoPlayer(
         } else {
             val isCurrent = controller.playingVideo == video
 
+            // Drawn underneath the player. While the player's view is hidden
+            // (before its first frame is rendered), this remains visible -
+            // avoiding a black flash when switching to the player.
+            VideoThumbnail(thumbnailFile)
+
             if (isCurrent) {
                 VideoPlayerExo(
                     video = video,
                     controller = controller,
                 )
-
-                // Keep the thumbnail on top until the player has rendered its first
-                // frame, so the player's surface (briefly black while preparing)
-                // is never shown to the user.
-                if (!controller.hasRenderedFirstFrame) {
-                    VideoThumbnail(thumbnailFile)
-                }
-            } else {
-                VideoThumbnail(thumbnailFile)
             }
         }
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerController.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerController.kt
@@ -12,6 +12,13 @@ class VideoPlayerController {
     var playingVideo: Video? by mutableStateOf(null)
 
     /**
+     * Whether the currently playing video has rendered its first frame.
+     * Used to keep showing a thumbnail until the player has something to show,
+     * avoiding a black flash while the player is preparing.
+     */
+    var hasRenderedFirstFrame by mutableStateOf(false)
+
+    /**
      * Pauses the video in a temporary way -
      * as opposed to [isTogglePaused], which is a toggle.
      * This is used for the functionality where a video should be pause only while it is 'held'

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
@@ -71,11 +71,21 @@ fun VideoPlayerExo(
                 ViewGroup.LayoutParams.MATCH_PARENT,
             )
 
+            // Hide the texture until the first frame is rendered, so the thumbnail
+            // drawn underneath remains visible instead of a black surface.
+            // AndroidView content is composited above Compose-drawn siblings, so
+            // hiding/showing this view (rather than the thumbnail) is what's needed
+            // to avoid the flash.
+            view.alpha = 0f
+
             // Stop playback of the previous video
             player.stop()
             player.setVideoTextureView(view)
 
             view
+        },
+        update = { view ->
+            view.alpha = if (controller.hasRenderedFirstFrame) 1f else 0f
         },
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
@@ -3,10 +3,12 @@ package com.lukeneedham.videodiary.ui.feature.common.videoplayer
 import android.view.TextureView
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import com.lukeneedham.videodiary.domain.model.Video
 import com.lukeneedham.videodiary.ui.media.VideoPlayerHolder
 import org.koin.compose.getKoin
@@ -23,7 +25,21 @@ fun VideoPlayerExo(
 
     val player = videoPlayerHolder.player
 
+    DisposableEffect(player, controller) {
+        val listener = object : Player.Listener {
+            override fun onRenderedFirstFrame() {
+                controller.hasRenderedFirstFrame = true
+            }
+        }
+        player.addListener(listener)
+        onDispose {
+            player.removeListener(listener)
+        }
+    }
+
     LaunchedEffect(video) {
+        controller.hasRenderedFirstFrame = false
+
         val videoMediaItem = when (video) {
             is Video.MediaStore -> MediaItem.fromUri(video.uri)
             is Video.PersistedFile -> MediaItem.fromUri(video.file.toUri())


### PR DESCRIPTION
Previously the thumbnail was replaced by the ExoPlayer surface as soon as a
video became "current", causing a black flash while the player prepared.
Now the thumbnail stays on top until Player.onRenderedFirstFrame fires.

https://claude.ai/code/session_01A2dNkrbyFp9AEBCzruBQdJ