### PR TITLE
Show day thumbnails in the date picker grid

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -180,6 +180,7 @@ object KoinModule {
         factory {
             DiaryDatePickerViewModel(
                 calendarRepository = get(),
+                videoResolutionRepository = get(),
                 mainDispatcher = get(KoinQualifier.Dispatcher.main)
             )
         }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -86,12 +84,16 @@ fun DiaryDatePicker(
 
     LazyColumn(
         state = state,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
         modifier = modifier
     ) {
         items(rows) { row ->
             when (row) {
                 is WeekRow.Normal -> {
-                    Row(modifier = Modifier.fillParentMaxWidth()) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(2.dp),
+                        modifier = Modifier.fillParentMaxWidth()
+                    ) {
                         row.week.forEach { weekday ->
                             Box(
                                 modifier = Modifier
@@ -99,12 +101,7 @@ fun DiaryDatePicker(
                             ) {
                                 when (weekday) {
                                     is Weekday.Empty -> {
-                                        Box(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .aspectRatio(videoAspectRatio)
-                                                .background(color = Color.Black)
-                                        )
+                                        // Nothing
                                     }
 
                                     is Weekday.Value -> {

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -96,7 +98,12 @@ fun DiaryDatePicker(
                             ) {
                                 when (weekday) {
                                     is Weekday.Empty -> {
-                                        // Nothing
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .aspectRatio(1f)
+                                                .background(color = Color.Black)
+                                        )
                                     }
 
                                     is Weekday.Value -> {

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
@@ -34,6 +34,7 @@ import java.time.LocalDate
 fun DiaryDatePicker(
     initialFocusedDate: LocalDate,
     weeks: List<List<Day>>,
+    videoAspectRatio: Float,
     onDateSelected: (LocalDate) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -101,7 +102,7 @@ fun DiaryDatePicker(
                                         Box(
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .aspectRatio(1f)
+                                                .aspectRatio(videoAspectRatio)
                                                 .background(color = Color.Black)
                                         )
                                     }
@@ -110,6 +111,7 @@ fun DiaryDatePicker(
                                         val day = weekday.day
                                         DiaryDatePickerDay(
                                             day = day,
+                                            videoAspectRatio = videoAspectRatio,
                                             onClick = {
                                                 onDateSelected(day.date)
                                             }
@@ -182,6 +184,7 @@ private fun Preview() {
     DiaryDatePicker(
         initialFocusedDate = MockDataDiaryDatePicker.endDate,
         weeks = MockDataDiaryDatePicker.weeks,
+        videoAspectRatio = MockDataDiaryDatePicker.videoAspectRatio,
         onDateSelected = {},
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDay.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDay.kt
@@ -34,6 +34,7 @@ import java.util.Locale
 @Composable
 fun DiaryDatePickerDay(
     day: Day,
+    videoAspectRatio: Float,
     onClick: () -> Unit,
 ) {
     val date = day.date
@@ -41,7 +42,7 @@ fun DiaryDatePickerDay(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .aspectRatio(1f)
+            .aspectRatio(videoAspectRatio)
             .background(Color.Black)
             .clickable { onClick() }
     ) {
@@ -53,29 +54,32 @@ fun DiaryDatePickerDay(
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .background(Color.Black.copy(alpha = 0.35f))
-                .padding(vertical = 2.dp)
+                .padding(vertical = 1.dp)
         ) {
             Text(
                 text = date.dayOfMonth.toString(),
                 color = Color.White,
                 fontWeight = FontWeight.Bold,
-                fontSize = 14.sp,
+                fontSize = 10.sp,
             )
-            Text(
-                text = date.month.getDisplayName(
-                    TextStyle.SHORT,
-                    Locale.getDefault()
-                ),
-                color = Color.White,
-                fontSize = 8.sp,
-            )
+            val isFirstDayOfMonth = date.dayOfMonth == 1
+            if (isFirstDayOfMonth) {
+                Text(
+                    text = date.month.getDisplayName(
+                        TextStyle.SHORT,
+                        Locale.getDefault()
+                    ),
+                    color = Color.White,
+                    fontSize = 7.sp,
+                )
+            }
             val isFirstDayOfYear = date.dayOfYear == 1
             if (isFirstDayOfYear) {
                 Text(
                     text = date.year.toString(),
                     color = Color.White,
                     fontWeight = FontWeight.Bold,
-                    fontSize = 7.sp,
+                    fontSize = 6.sp,
                 )
             }
         }
@@ -95,7 +99,7 @@ private fun DayThumbnail(thumbnailFile: File?) {
         Image(
             bitmap = bitmap.asImageBitmap(),
             contentDescription = null,
-            contentScale = ContentScale.Crop,
+            contentScale = ContentScale.Fit,
             modifier = Modifier.fillMaxSize(),
         )
     }
@@ -105,6 +109,8 @@ private fun DayThumbnail(thumbnailFile: File?) {
 @Composable
 internal fun PreviewDiaryDatePickerDay() {
     DiaryDatePickerDay(
-        day = MockDataDiaryDatePicker.day, onClick = {},
+        day = MockDataDiaryDatePicker.day,
+        videoAspectRatio = MockDataDiaryDatePicker.videoAspectRatio,
+        onClick = {},
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDay.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDay.kt
@@ -1,20 +1,33 @@
 package com.lukeneedham.videodiary.ui.feature.common.datepicker
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lukeneedham.videodiary.domain.model.Day
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
 import java.time.format.TextStyle
 import java.util.Locale
 
@@ -25,40 +38,66 @@ fun DiaryDatePickerDay(
 ) {
     val date = day.date
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Box(
         modifier = Modifier
-            .fillMaxSize()
-            .clickable {
-                onClick()
-            }
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .background(Color.Black)
+            .clickable { onClick() }
     ) {
-        val hasVideo = day.videoFile != null
-        val alpha = if (hasVideo) 1f else 0.4f
-        val color = Color.Black.copy(alpha = alpha)
+        DayThumbnail(thumbnailFile = day.thumbnailFile)
 
-        Spacer(modifier = Modifier.height(10.dp))
-        Text(
-            text = date.dayOfMonth.toString(),
-            color = color,
-            fontSize = 26.sp,
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(Color.Black.copy(alpha = 0.35f))
+                .padding(vertical = 2.dp)
+        ) {
+            Text(
+                text = date.dayOfMonth.toString(),
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+            )
+            Text(
+                text = date.month.getDisplayName(
+                    TextStyle.SHORT,
+                    Locale.getDefault()
+                ),
+                color = Color.White,
+                fontSize = 8.sp,
+            )
+            val isFirstDayOfYear = date.dayOfYear == 1
+            if (isFirstDayOfYear) {
+                Text(
+                    text = date.year.toString(),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 7.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayThumbnail(thumbnailFile: File?) {
+    if (thumbnailFile == null) return
+
+    val thumbnail by produceState<Bitmap?>(initialValue = null, thumbnailFile) {
+        value = withContext(Dispatchers.IO) {
+            BitmapFactory.decodeFile(thumbnailFile.absolutePath)
+        }
+    }
+    thumbnail?.let { bitmap ->
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
         )
-        Text(
-            text = date.month.getDisplayName(
-                TextStyle.SHORT,
-                Locale.getDefault()
-            ),
-            color = color,
-            fontSize = 13.sp,
-        )
-        val isFirstDayOfYear = date.dayOfYear == 1
-        Text(
-            text = if (isFirstDayOfYear) date.year.toString() else "",
-            color = color,
-            fontWeight = FontWeight.Bold,
-            fontSize = 9.sp,
-        )
-        Spacer(modifier = Modifier.height(20.dp))
     }
 }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
@@ -49,17 +49,23 @@ fun DiaryDatePickerDialog(
                 .background(color = Color.White, shape = RoundedCornerShape(10.dp))
         ) {
             Spacer(modifier = Modifier.height(10.dp))
-            DiaryDatePicker(
-                initialFocusedDate = initialFocusedDate,
-                weeks = viewModel.weeks,
-                onDateSelected = {
-                    onDateSelected(it)
-                    onDismiss()
-                },
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-            )
+            val videoAspectRatio = viewModel.videoAspectRatio
+            if (videoAspectRatio != null) {
+                DiaryDatePicker(
+                    initialFocusedDate = initialFocusedDate,
+                    weeks = viewModel.weeks,
+                    videoAspectRatio = videoAspectRatio,
+                    onDateSelected = {
+                        onDateSelected(it)
+                        onDismiss()
+                    },
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                )
+            } else {
+                Spacer(modifier = Modifier.weight(1f))
+            }
             Spacer(modifier = Modifier.height(5.dp))
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.lukeneedham.videodiary.data.repository.CalendarRepository
+import com.lukeneedham.videodiary.data.repository.VideoResolutionRepository
 import com.lukeneedham.videodiary.domain.model.Day
 import com.lukeneedham.videodiary.domain.util.date.CalendarUtil
 import kotlinx.coroutines.CoroutineDispatcher
@@ -13,11 +14,15 @@ import kotlinx.coroutines.launch
 
 class DiaryDatePickerViewModel(
     private val calendarRepository: CalendarRepository,
+    private val videoResolutionRepository: VideoResolutionRepository,
     private val mainDispatcher: CoroutineDispatcher,
 ) {
     private val scope = CoroutineScope(mainDispatcher)
 
     var weeks by mutableStateOf<List<List<Day>>>(emptyList())
+        private set
+
+    var videoAspectRatio by mutableStateOf<Float?>(null)
         private set
 
     init {
@@ -28,6 +33,9 @@ class DiaryDatePickerViewModel(
                     getDate = { it.date }
                 )
             }
+        }
+        scope.launch {
+            videoAspectRatio = videoResolutionRepository.getAspectRatio()
         }
     }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/MockDataDiaryDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/MockDataDiaryDatePicker.kt
@@ -18,4 +18,6 @@ object MockDataDiaryDatePicker {
         )
     }
     val weeks = CalendarUtil.chunkIntoWeeks(days) { it.date }
+
+    val videoAspectRatio = 9f / 16f
 }


### PR DESCRIPTION
Each date picker cell now renders the day's thumbnail (or black if
none exists) with the date overlaid in white at the bottom.