### PR TITLE
Fix video not rendering on review/export screens

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/view/ExportDiaryViewPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/view/ExportDiaryViewPageContent.kt
@@ -46,6 +46,7 @@ fun ExportDiaryViewPageContent(
     val controller = remember {
         VideoPlayerController().apply {
             isVolumeOn = true
+            playingVideo = Video.PersistedFile(videoFile)
         }
     }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -32,7 +32,11 @@ fun CheckVideoPageContent(
     onRetakeClick: () -> Unit,
     onAccepted: () -> Unit,
 ) {
-    val videoPlayerController = remember { VideoPlayerController() }
+    val videoPlayerController = remember {
+        VideoPlayerController().apply {
+            playingVideo = video
+        }
+    }
     Box(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
VideoPlayer only renders the ExoPlayer surface when
controller.playingVideo == video, but CheckVideoPageContent and
ExportDiaryViewPageContent never set playingVideo, so the check
always failed and only the (missing) thumbnail showed.

https://claude.ai/code/session_01UF5pM3VMNVYa5QCgUD2jr4