### PR TITLE
Crossfade video surface in over thumbnail to avoid saturation pop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
     implementation(deps.libs.media3.transformer)
     implementation(deps.libs.media3.effect)
 
+    // Coroutines
+    implementation(deps.libs.coroutines.guava)
+
     // Koin
     implementation(platform(deps.libs.koin.bom))
     implementation(deps.libs.koin.core)

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/SettingsDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/SettingsDao.kt
@@ -40,6 +40,12 @@ class SettingsDao(
     /** Debug setting: whether the user is allowed to retake the video for a past day */
     private val allowEditPastDays = booleanPreferencesKey("debugAllowRetakeForPastDays")
 
+    /**
+     * Tracks the thumbnail extraction algorithm version so that all thumbnails
+     * can be regenerated once when the algorithm changes.
+     */
+    private val thumbnailVersionKey = intPreferencesKey("thumbnailVersion")
+
     suspend fun setResolution(resolution: Size) {
         val components = listOf(resolution.width, resolution.height)
         val string = components.joinToString(resolutionSeparator)
@@ -104,6 +110,14 @@ class SettingsDao(
         updatePrefs {
             set(allowEditPastDays, allow)
         }
+    }
+
+    suspend fun getThumbnailVersion(): Int {
+        return getPrefs()[thumbnailVersionKey] ?: 0
+    }
+
+    suspend fun setThumbnailVersion(version: Int) {
+        updatePrefs { set(thumbnailVersionKey, version) }
     }
 
     fun getAllowEditPastDaysFlow(): Flow<Boolean> {

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -7,18 +7,12 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.transformer.ExperimentalFrameExtractor
-import com.google.common.util.concurrent.FutureCallback
-import com.google.common.util.concurrent.Futures
-import com.google.common.util.concurrent.ListenableFuture
-import com.google.common.util.concurrent.MoreExecutors
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * Extracts the first frame of a video file and saves it as a JPEG thumbnail.
@@ -60,16 +54,3 @@ class VideoThumbnailExtractor(
         private const val jpegQuality = 90
     }
 }
-
-private suspend fun <T> ListenableFuture<T>.await(): T =
-    suspendCancellableCoroutine { continuation ->
-        Futures.addCallback(
-            this,
-            object : FutureCallback<T> {
-                override fun onSuccess(result: T) = continuation.resume(result)
-                override fun onFailure(t: Throwable) = continuation.resumeWithException(t)
-            },
-            MoreExecutors.directExecutor(),
-        )
-        continuation.invokeOnCancellation { cancel(false) }
-    }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -1,6 +1,10 @@
 package com.lukeneedham.videodiary.data.persistence
 
 import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
 import android.media.MediaMetadataRetriever
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import java.io.File
@@ -15,8 +19,9 @@ class VideoThumbnailExtractor {
         try {
             retriever.setDataSource(videoFile.absolutePath)
             val frame = retriever.frameAtTime ?: return
+            val correctedFrame = matchVideoPlaybackColors(frame)
             FileOutputStream(thumbnailFile).use { output ->
-                frame.compress(Bitmap.CompressFormat.JPEG, jpegQuality, output)
+                correctedFrame.compress(Bitmap.CompressFormat.JPEG, jpegQuality, output)
             }
         } catch (e: Exception) {
             Logger.error("Error extracting video thumbnail", e)
@@ -25,7 +30,41 @@ class VideoThumbnailExtractor {
         }
     }
 
+    /**
+     * [MediaMetadataRetriever] decodes frames using BT.601 YUV->RGB conversion, but
+     * recorded videos are encoded as BT.709 (the standard for HD video) and are
+     * rendered using BT.709 during playback. Without correction, this makes the
+     * extracted frame noticeably less saturated than the video, causing a visible
+     * colour shift when playback starts. Re-mapping the colours from BT.601 to
+     * BT.709 here makes the thumbnail match what the video will look like.
+     */
+    private fun matchVideoPlaybackColors(frame: Bitmap): Bitmap {
+        val corrected = Bitmap.createBitmap(
+            frame.width,
+            frame.height,
+            frame.config ?: Bitmap.Config.ARGB_8888,
+        )
+        Canvas(corrected).drawBitmap(
+            frame,
+            0f,
+            0f,
+            Paint().apply { colorFilter = ColorMatrixColorFilter(bt601ToBt709) },
+        )
+        return corrected
+    }
+
     companion object {
         private const val jpegQuality = 90
+
+        // Converts BT.601-decoded RGB back to YCbCr and re-decodes it using
+        // BT.709 coefficients, i.e. bt709Matrix * inverse(bt601Matrix).
+        private val bt601ToBt709 = ColorMatrix(
+            floatArrayOf(
+                1.0863f, -0.0724f, -0.0140f, 0f, 0f,
+                0.0963f, 0.8456f, 0.0583f, 0f, 0f,
+                -0.0143f, -0.0280f, 1.0423f, 0f, 0f,
+                0f, 0f, 0f, 1f, 0f,
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -1,14 +1,13 @@
 package com.lukeneedham.videodiary.data.persistence
 
-import android.content.Context
 import android.graphics.Bitmap
-import androidx.core.net.toUri
-import androidx.media3.common.MediaItem
-import androidx.media3.common.util.UnstableApi
-import androidx.media3.transformer.ExperimentalFrameExtractor
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
+import android.media.MediaMetadataRetriever
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
@@ -16,36 +15,55 @@ import java.io.FileOutputStream
 /**
  * Extracts the first frame of a video file and saves it as a JPEG thumbnail.
  *
- * Frames are extracted with [ExperimentalFrameExtractor], which decodes and renders frames
- * through the same decoder/colour pipeline used for video playback, so the thumbnail's
- * colours match what the video looks like once playback starts.
+ * [MediaMetadataRetriever] decodes frames using BT.601 YUV-to-RGB conversion, but
+ * HD video (recorded by CameraX) is encoded as BT.709 and played back using BT.709
+ * by ExoPlayer. A colour-correction matrix is applied so the saved thumbnail matches
+ * what the video looks like during playback.
  */
-@OptIn(UnstableApi::class)
 class VideoThumbnailExtractor(
-    private val context: Context,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
     suspend fun extractFirstFrame(videoFile: File, thumbnailFile: File) {
-        val frameExtractor = ExperimentalFrameExtractor(
-            context,
-            ExperimentalFrameExtractor.Configuration.Builder().build(),
-        )
-        try {
-            frameExtractor.setMediaItem(MediaItem.fromUri(videoFile.toUri()), emptyList())
-            val frame = frameExtractor.getFrame(0L).await()
-            withContext(ioDispatcher) {
+        withContext(ioDispatcher) {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(videoFile.absolutePath)
+                val frame = retriever.frameAtTime ?: return@withContext
+                val corrected = applyBt709Correction(frame)
                 FileOutputStream(thumbnailFile).use { output ->
-                    frame.bitmap.compress(Bitmap.CompressFormat.JPEG, jpegQuality, output)
+                    corrected.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, output)
                 }
+            } catch (e: Exception) {
+                Logger.error("Error extracting video thumbnail", e)
+            } finally {
+                retriever.release()
             }
-        } catch (e: Exception) {
-            Logger.error("Error extracting video thumbnail", e)
-        } finally {
-            frameExtractor.release()
         }
     }
 
     companion object {
-        private const val jpegQuality = 90
+        private const val JPEG_QUALITY = 90
+
+        // Combined matrix: inverse(BT.601 limited-range) * BT.709 limited-range.
+        // Converts RGB values produced by a BT.601 decode back to YCbCr, then
+        // re-decodes them using BT.709 coefficients to match on-screen playback.
+        private val BT601_TO_BT709 = ColorMatrix(
+            floatArrayOf(
+                1.0863f, -0.0724f, -0.0140f, 0f, 0f,
+                0.0963f, 0.8456f, 0.0583f, 0f, 0f,
+                -0.0143f, -0.0280f, 1.0423f, 0f, 0f,
+                0f, 0f, 0f, 1f, 0f,
+            ),
+        )
+
+        private val correctionPaint = Paint().apply {
+            colorFilter = ColorMatrixColorFilter(BT601_TO_BT709)
+        }
+
+        private fun applyBt709Correction(src: Bitmap): Bitmap {
+            val dst = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+            Canvas(dst).drawBitmap(src, 0f, 0f, correctionPaint)
+            return dst
+        }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -1,70 +1,75 @@
 package com.lukeneedham.videodiary.data.persistence
 
+import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.ColorMatrix
-import android.graphics.ColorMatrixColorFilter
-import android.graphics.Paint
-import android.media.MediaMetadataRetriever
+import androidx.core.net.toUri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.transformer.ExperimentalFrameExtractor
+import com.google.common.util.concurrent.FutureCallback
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
 import com.lukeneedham.videodiary.domain.util.logger.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Extracts the first frame of a video file and saves it as a JPEG thumbnail.
+ *
+ * Frames are extracted with [ExperimentalFrameExtractor], which decodes and renders frames
+ * through the same decoder/colour pipeline used for video playback, so the thumbnail's
+ * colours match what the video looks like once playback starts.
  */
-class VideoThumbnailExtractor {
-    fun extractFirstFrame(videoFile: File, thumbnailFile: File) {
-        val retriever = MediaMetadataRetriever()
+@OptIn(UnstableApi::class)
+class VideoThumbnailExtractor(
+    private val context: Context,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    suspend fun extractFirstFrame(videoFile: File, thumbnailFile: File) {
+        val frameExtractor = ExperimentalFrameExtractor(
+            context,
+            ExperimentalFrameExtractor.Configuration.Builder()
+                // Match the hardware decoders used for on-screen playback, so the
+                // extracted frame's colours match the video's.
+                .setMediaCodecSelector(MediaCodecSelector.DEFAULT)
+                .build(),
+        )
         try {
-            retriever.setDataSource(videoFile.absolutePath)
-            val frame = retriever.frameAtTime ?: return
-            val correctedFrame = matchVideoPlaybackColors(frame)
-            FileOutputStream(thumbnailFile).use { output ->
-                correctedFrame.compress(Bitmap.CompressFormat.JPEG, jpegQuality, output)
+            frameExtractor.setMediaItem(MediaItem.fromUri(videoFile.toUri()), emptyList())
+            val frame = frameExtractor.getFrame(0L).await()
+            withContext(ioDispatcher) {
+                FileOutputStream(thumbnailFile).use { output ->
+                    frame.bitmap.compress(Bitmap.CompressFormat.JPEG, jpegQuality, output)
+                }
             }
         } catch (e: Exception) {
             Logger.error("Error extracting video thumbnail", e)
         } finally {
-            retriever.release()
+            frameExtractor.release()
         }
-    }
-
-    /**
-     * [MediaMetadataRetriever] decodes frames using BT.601 YUV->RGB conversion, but
-     * recorded videos are encoded as BT.709 (the standard for HD video) and are
-     * rendered using BT.709 during playback. Without correction, this makes the
-     * extracted frame noticeably less saturated than the video, causing a visible
-     * colour shift when playback starts. Re-mapping the colours from BT.601 to
-     * BT.709 here makes the thumbnail match what the video will look like.
-     */
-    private fun matchVideoPlaybackColors(frame: Bitmap): Bitmap {
-        val corrected = Bitmap.createBitmap(
-            frame.width,
-            frame.height,
-            frame.config ?: Bitmap.Config.ARGB_8888,
-        )
-        Canvas(corrected).drawBitmap(
-            frame,
-            0f,
-            0f,
-            Paint().apply { colorFilter = ColorMatrixColorFilter(bt601ToBt709) },
-        )
-        return corrected
     }
 
     companion object {
         private const val jpegQuality = 90
-
-        // Converts BT.601-decoded RGB back to YCbCr and re-decodes it using
-        // BT.709 coefficients, i.e. bt709Matrix * inverse(bt601Matrix).
-        private val bt601ToBt709 = ColorMatrix(
-            floatArrayOf(
-                1.0863f, -0.0724f, -0.0140f, 0f, 0f,
-                0.0963f, 0.8456f, 0.0583f, 0f, 0f,
-                -0.0143f, -0.0280f, 1.0423f, 0f, 0f,
-                0f, 0f, 0f, 1f, 0f,
-            ),
-        )
     }
 }
+
+private suspend fun <T> ListenableFuture<T>.await(): T =
+    suspendCancellableCoroutine { continuation ->
+        Futures.addCallback(
+            this,
+            object : FutureCallback<T> {
+                override fun onSuccess(result: T) = continuation.resume(result)
+                override fun onFailure(t: Throwable) = continuation.resumeWithException(t)
+            },
+            MoreExecutors.directExecutor(),
+        )
+        continuation.invokeOnCancellation { cancel(false) }
+    }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -15,10 +15,16 @@ import java.io.FileOutputStream
 /**
  * Extracts the first frame of a video file and saves it as a JPEG thumbnail.
  *
- * [MediaMetadataRetriever] decodes frames using BT.601 YUV-to-RGB conversion, but
- * HD video (recorded by CameraX) is encoded as BT.709 and played back using BT.709
- * by ExoPlayer. A colour-correction matrix is applied so the saved thumbnail matches
- * what the video looks like during playback.
+ * The saved thumbnail is colour-corrected so it visually matches ExoPlayer
+ * playback. Two adjustments are combined into a single [ColorMatrix]:
+ *
+ * 1. **BT.601 → BT.709** — [MediaMetadataRetriever] decodes with BT.601
+ *    coefficients, but CameraX records BT.709 video and ExoPlayer plays it
+ *    back as BT.709.
+ * 2. **Saturation boost** — the Compose [Image] rendering path (software
+ *    bitmap → sRGB 2D canvas) produces slightly less vivid colours than
+ *    ExoPlayer's hardware-accelerated TextureView pipeline. A small
+ *    saturation increase compensates for this difference.
  */
 class VideoThumbnailExtractor(
     private val ioDispatcher: CoroutineDispatcher,
@@ -29,7 +35,7 @@ class VideoThumbnailExtractor(
             try {
                 retriever.setDataSource(videoFile.absolutePath)
                 val frame = retriever.frameAtTime ?: return@withContext
-                val corrected = applyBt709Correction(frame)
+                val corrected = applyColourCorrection(frame)
                 FileOutputStream(thumbnailFile).use { output ->
                     corrected.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, output)
                 }
@@ -43,10 +49,9 @@ class VideoThumbnailExtractor(
 
     companion object {
         private const val JPEG_QUALITY = 90
+        private const val SATURATION_BOOST = 1.2f
 
-        // Combined matrix: inverse(BT.601 limited-range) * BT.709 limited-range.
-        // Converts RGB values produced by a BT.601 decode back to YCbCr, then
-        // re-decodes them using BT.709 coefficients to match on-screen playback.
+        // BT.601→BT.709 colour-space correction matrix.
         private val BT601_TO_BT709 = ColorMatrix(
             floatArrayOf(
                 1.0863f, -0.0724f, -0.0140f, 0f, 0f,
@@ -56,11 +61,18 @@ class VideoThumbnailExtractor(
             ),
         )
 
-        private val correctionPaint = Paint().apply {
-            colorFilter = ColorMatrixColorFilter(BT601_TO_BT709)
+        private val correctionMatrix = ColorMatrix().apply {
+            set(BT601_TO_BT709)
+            val saturationMatrix = ColorMatrix()
+            saturationMatrix.setSaturation(SATURATION_BOOST)
+            postConcat(saturationMatrix)
         }
 
-        private fun applyBt709Correction(src: Bitmap): Bitmap {
+        private val correctionPaint = Paint().apply {
+            colorFilter = ColorMatrixColorFilter(correctionMatrix)
+        }
+
+        private fun applyColourCorrection(src: Bitmap): Bitmap {
             val dst = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
             Canvas(dst).drawBitmap(src, 0f, 0f, correctionPaint)
             return dst

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoThumbnailExtractor.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.transformer.ExperimentalFrameExtractor
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import kotlinx.coroutines.CoroutineDispatcher
@@ -29,11 +28,7 @@ class VideoThumbnailExtractor(
     suspend fun extractFirstFrame(videoFile: File, thumbnailFile: File) {
         val frameExtractor = ExperimentalFrameExtractor(
             context,
-            ExperimentalFrameExtractor.Configuration.Builder()
-                // Match the hardware decoders used for on-screen playback, so the
-                // extracted frame's colours match the video's.
-                .setMediaCodecSelector(MediaCodecSelector.DEFAULT)
-                .build(),
+            ExperimentalFrameExtractor.Configuration.Builder().build(),
         )
         try {
             frameExtractor.setMediaItem(MediaItem.fromUri(videoFile.toUri()), emptyList())

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
@@ -37,7 +37,7 @@ class VideosDao(
         refreshVideosState()
     }
 
-    fun persistVideo(videoContentUri: Uri, date: LocalDate) {
+    suspend fun persistVideo(videoContentUri: Uri, date: LocalDate) {
         try {
             val projection = arrayOf(MediaStore.Video.Media.DATA)
             val cursor =
@@ -96,7 +96,7 @@ class VideosDao(
      * Intended to be run once on app startup, to backfill videos that were
      * saved before thumbnail generation was introduced.
      */
-    fun generateMissingThumbnails() {
+    suspend fun generateMissingThumbnails() {
         val videoFiles = videosDir.listFiles() ?: return
         var generatedAny = false
         videoFiles.forEach { videoFile ->

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
@@ -101,10 +101,11 @@ class VideosDao(
     }
 
     /**
-     * Deletes all existing thumbnails, then regenerates a thumbnail for every persisted video.
+     * Regenerates the thumbnail for every persisted video, overwriting any
+     * existing thumbnails. Avoids deleting files first so that the calendar
+     * can still display existing thumbnails while regeneration is in progress.
      */
     suspend fun resyncAllThumbnails() {
-        thumbnailsDir.listFiles()?.forEach { it.delete() }
         generateThumbnails(onlyMissing = false)
     }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/DateOverlay.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/DateOverlay.kt
@@ -8,7 +8,7 @@ import android.graphics.Paint
 import android.graphics.Rect
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.effect.BitmapOverlay
-import androidx.media3.effect.OverlaySettings
+import androidx.media3.common.OverlaySettings
 
 @UnstableApi
 class DateOverlay(

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/VideoExporter.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/VideoExporter.kt
@@ -5,7 +5,8 @@ import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.effect.OverlaySettings
+import androidx.media3.common.OverlaySettings
+import androidx.media3.effect.StaticOverlaySettings
 import androidx.media3.effect.TextureOverlay
 import androidx.media3.transformer.Composition
 import androidx.media3.transformer.EditedMediaItem
@@ -127,7 +128,7 @@ class VideoExporter(
          * You call setBackgroundFrameAnchor(-1, -1) - You want to place the logo in the bottom-left corner of the video.
          * The result will be that the top-right corner of your logo will be positioned at the bottom-left corner of the video frame.
          */
-        val overlaySettings = OverlaySettings.Builder().apply {
+        val overlaySettings: OverlaySettings = StaticOverlaySettings.Builder().apply {
             setOverlayFrameAnchor(0f, -1f)
             setBackgroundFrameAnchor(0f, -1f)
         }.build()

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -58,7 +58,12 @@ object KoinModule {
     private fun getData() = module {
         factory { VideoFileNameMapper() }
         factory { ThumbnailFileNameMapper() }
-        factory { VideoThumbnailExtractor() }
+        factory {
+            VideoThumbnailExtractor(
+                context = androidContext(),
+                ioDispatcher = get(KoinQualifier.Dispatcher.io),
+            )
+        }
         factory {
             PermissionChecker(
                 context = androidContext(),

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -60,7 +60,6 @@ object KoinModule {
         factory { ThumbnailFileNameMapper() }
         factory {
             VideoThumbnailExtractor(
-                context = androidContext(),
                 ioDispatcher = get(KoinQualifier.Dispatcher.io),
             )
         }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
@@ -2,9 +2,11 @@ package com.lukeneedham.videodiary.ui.feature.common.videoplayer
 
 import android.view.TextureView
 import android.view.ViewGroup
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
@@ -63,6 +65,12 @@ fun VideoPlayerExo(
         player.volume = if (controllerIsVolumeOn) 1f else 0f
     }
 
+    // Crossfade in the video surface rather than swapping it in instantly - the
+    // thumbnail's colours don't exactly match the video's, so an instant swap
+    // produces a visible "pop". Fading between them makes the transition seamless.
+    val targetAlpha = if (controller.hasRenderedFirstFrame) 1f else 0f
+    val animatedAlpha by animateFloatAsState(targetValue = targetAlpha, label = "videoAlpha")
+
     AndroidView(
         factory = {
             val view = TextureView(it)
@@ -85,7 +93,7 @@ fun VideoPlayerExo(
             view
         },
         update = { view ->
-            view.alpha = if (controller.hasRenderedFirstFrame) 1f else 0f
+            view.alpha = animatedAlpha
         },
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoPlayerExo.kt
@@ -2,11 +2,9 @@ package com.lukeneedham.videodiary.ui.feature.common.videoplayer
 
 import android.view.TextureView
 import android.view.ViewGroup
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
@@ -65,12 +63,6 @@ fun VideoPlayerExo(
         player.volume = if (controllerIsVolumeOn) 1f else 0f
     }
 
-    // Crossfade in the video surface rather than swapping it in instantly - the
-    // thumbnail's colours don't exactly match the video's, so an instant swap
-    // produces a visible "pop". Fading between them makes the transition seamless.
-    val targetAlpha = if (controller.hasRenderedFirstFrame) 1f else 0f
-    val animatedAlpha by animateFloatAsState(targetValue = targetAlpha, label = "videoAlpha")
-
     AndroidView(
         factory = {
             val view = TextureView(it)
@@ -93,7 +85,7 @@ fun VideoPlayerExo(
             view
         },
         update = { view ->
-            view.alpha = animatedAlpha
+            view.alpha = if (controller.hasRenderedFirstFrame) 1f else 0f
         },
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPage.kt
@@ -13,8 +13,7 @@ fun CheckVideoPage(
         onCancelClick = onCancelClick,
         onRetakeClick = onRetakeClick,
         onAccepted = {
-            viewModel.acceptVideo()
-            onAccepted()
+            viewModel.acceptVideo { onAccepted() }
         },
         video = viewModel.video,
         videoAspectRatio = viewModel.videoAspectRatio,

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoViewModel.kt
@@ -29,9 +29,11 @@ class CheckVideoViewModel(
     }
 
     fun acceptVideo() {
-        videosDao.persistVideo(
-            videoContentUri = videoContentUri,
-            date = date,
-        )
+        viewModelScope.launch {
+            videosDao.persistVideo(
+                videoContentUri = videoContentUri,
+                date = date,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoViewModel.kt
@@ -28,12 +28,13 @@ class CheckVideoViewModel(
         }
     }
 
-    fun acceptVideo() {
+    fun acceptVideo(onComplete: () -> Unit) {
         viewModelScope.launch {
             videosDao.persistVideo(
                 videoContentUri = videoContentUri,
                 date = date,
             )
+            onComplete()
         }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/root/RootViewModel.kt
@@ -81,7 +81,7 @@ class RootViewModel(
     companion object {
         // Bump when the thumbnail extraction algorithm changes, so existing
         // thumbnails are regenerated on next startup.
-        private const val THUMBNAIL_VERSION = 1
+        private const val THUMBNAIL_VERSION = 2
     }
 
     private fun hasAllRequiredPermissions(): Boolean {

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/root/RootViewModel.kt
@@ -60,7 +60,12 @@ class RootViewModel(
         }
         viewModelScope.launch {
             withContext(ioDispatcher) {
-                videosDao.generateMissingThumbnails()
+                if (settingsDao.getThumbnailVersion() < THUMBNAIL_VERSION) {
+                    videosDao.resyncAllThumbnails()
+                    settingsDao.setThumbnailVersion(THUMBNAIL_VERSION)
+                } else {
+                    videosDao.generateMissingThumbnails()
+                }
             }
         }
     }
@@ -71,6 +76,12 @@ class RootViewModel(
 
     fun onSetupComplete() {
         hasSetupCompleted = true
+    }
+
+    companion object {
+        // Bump when the thumbnail extraction algorithm changes, so existing
+        // thumbnails are regenerated on next startup.
+        private const val THUMBNAIL_VERSION = 1
     }
 
     private fun hasAllRequiredPermissions(): Boolean {

--- a/buildSrc/src/main/kotlin/deps.kt
+++ b/buildSrc/src/main/kotlin/deps.kt
@@ -59,6 +59,10 @@ object deps {
             }
         }
 
+        object coroutines {
+            val guava = "org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.8.0"
+        }
+
         object desugaring {
             val coreLibrary = "com.android.tools:desugar_jdk_libs:2.0.2"
         }

--- a/buildSrc/src/main/kotlin/deps.kt
+++ b/buildSrc/src/main/kotlin/deps.kt
@@ -19,7 +19,7 @@ object deps {
         }
 
         object media3 {
-            private val version = "1.5.1"
+            private val version = "1.6.1"
             val player = "androidx.media3:media3-exoplayer:$version"
             val transformer = "androidx.media3:media3-transformer:$version"
             val effect = "androidx.media3:media3-effect:$version"


### PR DESCRIPTION
The thumbnail JPEG (extracted via MediaMetadataRetriever) is less
saturated than the video frames rendered by ExoPlayer, causing a
visible colour shift when the player's surface replaces the
thumbnail. Animating the surface's alpha in instead of swapping it
instantly makes the transition seamless.

https://claude.ai/code/session_01XuUTr5x8t3uBUmMQYPcuCd