### PR TITLE
Add debug option to resync all thumbnails

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideosDao.kt
@@ -97,6 +97,18 @@ class VideosDao(
      * saved before thumbnail generation was introduced.
      */
     fun generateMissingThumbnails() {
+        generateThumbnails(onlyMissing = true)
+    }
+
+    /**
+     * Deletes all existing thumbnails, then regenerates a thumbnail for every persisted video.
+     */
+    fun resyncAllThumbnails() {
+        thumbnailsDir.listFiles()?.forEach { it.delete() }
+        generateThumbnails(onlyMissing = false)
+    }
+
+    private fun generateThumbnails(onlyMissing: Boolean) {
         val videoFiles = videosDir.listFiles() ?: return
         var generatedAny = false
         videoFiles.forEach { videoFile ->
@@ -108,7 +120,7 @@ class VideosDao(
             }
 
             val thumbnailFile = getThumbnailFile(date)
-            if (!thumbnailFile.exists()) {
+            if (!onlyMissing || !thumbnailFile.exists()) {
                 videoThumbnailExtractor.extractFirstFrame(videoFile, thumbnailFile)
                 generatedAny = true
             }

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -172,6 +172,8 @@ object KoinModule {
             DebugViewModel(
                 mockDataRepository = get(),
                 settingsDao = get(),
+                videosDao = get(),
+                ioDispatcher = get(KoinQualifier.Dispatcher.io),
             )
         }
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPage.kt
@@ -16,6 +16,7 @@ fun DebugPage(
         onFillWithMockDataClick = viewModel::fillWithMockData,
         allowRetakeForPastDays = allowRetakeForPastDays,
         onAllowRetakeForPastDaysChange = viewModel::setAllowRetakeForPastDays,
+        onResyncThumbnailsClick = viewModel::resyncThumbnails,
         canGoBack = canGoBack,
         onBack = onBack,
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPageContent.kt
@@ -25,6 +25,7 @@ fun DebugPageContent(
     onFillWithMockDataClick: () -> Unit,
     allowRetakeForPastDays: Boolean,
     onAllowRetakeForPastDaysChange: (Boolean) -> Unit,
+    onResyncThumbnailsClick: () -> Unit,
     canGoBack: Boolean,
     onBack: () -> Unit,
 ) {
@@ -61,6 +62,13 @@ fun DebugPageContent(
                     "for that day to be re-recorded. Normally only today's video can be retaken",
                 checked = allowRetakeForPastDays,
                 onCheckedChange = onAllowRetakeForPastDaysChange,
+            )
+
+            DebugOption(
+                title = "Resync thumbnails",
+                description = "Deletes all generated thumbnails and recalculates them " +
+                    "from the saved videos",
+                onClick = onResyncThumbnailsClick,
             )
         }
     }
@@ -134,6 +142,7 @@ internal fun PreviewDebugPageContent() {
         onFillWithMockDataClick = {},
         allowRetakeForPastDays = false,
         onAllowRetakeForPastDaysChange = {},
+        onResyncThumbnailsClick = {},
         canGoBack = true,
         onBack = {},
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugViewModel.kt
@@ -3,15 +3,20 @@ package com.lukeneedham.videodiary.ui.feature.debug
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lukeneedham.videodiary.data.persistence.SettingsDao
+import com.lukeneedham.videodiary.data.persistence.VideosDao
 import com.lukeneedham.videodiary.data.repository.MockDataRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class DebugViewModel(
     private val mockDataRepository: MockDataRepository,
     private val settingsDao: SettingsDao,
+    private val videosDao: VideosDao,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     val allowRetakeForPastDays: StateFlow<Boolean> = settingsDao.getAllowEditPastDaysFlow()
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
@@ -23,6 +28,14 @@ class DebugViewModel(
     fun setAllowRetakeForPastDays(allow: Boolean) {
         viewModelScope.launch {
             settingsDao.setDebugAllowRetakeForPastDays(allow)
+        }
+    }
+
+    fun resyncThumbnails() {
+        viewModelScope.launch {
+            withContext(ioDispatcher) {
+                videosDao.resyncAllThumbnails()
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a "Resync thumbnails" debug action that deletes all generated
thumbnail files and regenerates them from the saved videos.

https://claude.ai/code/session_018hn7U3ZPE1J95RLTAt8Se4