### PR TITLE
Add tap-to-focus on camera preview

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
@@ -171,7 +171,7 @@ fun CameraInput(
             Canvas(modifier = Modifier.fillMaxSize()) {
                 drawCircle(
                     color = Color.White.copy(alpha = focusAlpha.value),
-                    radius = 40.dp.toPx(),
+                    radius = 25.dp.toPx(),
                     center = currentFocusTapOffset,
                     style = Stroke(width = 2.dp.toPx())
                 )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
@@ -119,7 +119,7 @@ fun CameraInput(
     LaunchedEffect(focusTapCount) {
         if (focusTapCount == 0) return@LaunchedEffect
         focusAlpha.snapTo(1f)
-        delay(1000)
+        delay(700)
         focusAlpha.animateTo(0f, animationSpec = tween(500))
         focusTapOffset = null
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
@@ -120,7 +120,7 @@ fun CameraInput(
         if (focusTapCount == 0) return@LaunchedEffect
         focusAlpha.snapTo(0.7f)
         delay(700)
-        focusAlpha.animateTo(0f, animationSpec = tween(500))
+        focusAlpha.animateTo(0f, animationSpec = tween(400))
         focusTapOffset = null
     }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
@@ -119,7 +119,7 @@ fun CameraInput(
     LaunchedEffect(focusTapCount) {
         if (focusTapCount == 0) return@LaunchedEffect
         focusAlpha.snapTo(0.7f)
-        delay(700)
+        delay(500)
         focusAlpha.animateTo(0f, animationSpec = tween(400))
         focusTapOffset = null
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
@@ -118,7 +118,7 @@ fun CameraInput(
     // Animate focus indicator: snap in, hold, then fade out
     LaunchedEffect(focusTapCount) {
         if (focusTapCount == 0) return@LaunchedEffect
-        focusAlpha.snapTo(1f)
+        focusAlpha.snapTo(0.7f)
         delay(700)
         focusAlpha.animateTo(0f, animationSpec = tween(500))
         focusTapOffset = null

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/camera/CameraInput.kt
@@ -4,13 +4,18 @@ import android.util.Log
 import android.util.Size
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
+import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.Preview
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.Recorder
 import androidx.camera.video.VideoCapture
 import androidx.camera.view.PreviewView
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,19 +23,24 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import com.lukeneedham.videodiary.domain.model.CameraResolutionRotation
+import kotlinx.coroutines.delay
 
 @Composable
 fun CameraInput(
@@ -52,6 +62,10 @@ fun CameraInput(
 
     var resolutionMissing by remember(currentResolution) { mutableStateOf(false) }
     var camera: Camera? by remember { mutableStateOf(null) }
+
+    var focusTapOffset by remember { mutableStateOf<Offset?>(null) }
+    var focusTapCount by remember { mutableIntStateOf(0) }
+    val focusAlpha = remember { Animatable(0f) }
 
     val previewUseCase = remember(previewView, currentResolution) {
         val resolutionSelector = ResolutionSelector.Builder()
@@ -101,11 +115,32 @@ fun CameraInput(
         setupPreview()
     }
 
+    // Animate focus indicator: snap in, hold, then fade out
+    LaunchedEffect(focusTapCount) {
+        if (focusTapCount == 0) return@LaunchedEffect
+        focusAlpha.snapTo(1f)
+        delay(1000)
+        focusAlpha.animateTo(0f, animationSpec = tween(500))
+        focusTapOffset = null
+    }
+
+    val currentFocusTapOffset = focusTapOffset
+
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
             .fillMaxSize()
             .background(color = Color.Black)
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val cam = camera ?: return@detectTapGestures
+                    val point = previewView.meteringPointFactory.createPoint(offset.x, offset.y)
+                    val action = FocusMeteringAction.Builder(point).build()
+                    cam.cameraControl.startFocusAndMetering(action)
+                    focusTapOffset = offset
+                    focusTapCount++
+                }
+            }
             .pointerInput(Unit) {
                 detectTransformGestures { _, _, zoomChange, _ ->
                     if (!canZoomUpdated) return@detectTransformGestures
@@ -130,6 +165,17 @@ fun CameraInput(
                 factory = { previewView },
                 modifier = Modifier.fillMaxSize()
             )
+        }
+
+        if (currentFocusTapOffset != null) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawCircle(
+                    color = Color.White.copy(alpha = focusAlpha.value),
+                    radius = 40.dp.toPx(),
+                    center = currentFocusTapOffset,
+                    style = Stroke(width = 2.dp.toPx())
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Tapping the camera preview triggers CameraX focus metering at that point
via FocusMeteringAction. A white circle indicator appears at the tap
location and fades out after ~1.5s.

https://claude.ai/code/session_01ErBFKhCvxCizmN6vex6kkG