### PR TITLE
Optimize GitHub Actions build speed

### DIFF
--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -1,10 +1,11 @@
 name: On Pull Request
 
 on:
-    workflow_call:
+    workflow_call: # Makes sure this job can be acted.
     workflow_dispatch: {}
     pull_request:
         branches:
+            # The following branches are worth running the checks on
             - main
 
 # Cancel in-progress runs for the same PR/branch — only the latest push matters
@@ -14,42 +15,59 @@ concurrency:
 
 permissions:
   id-token: write
-  contents: write
-  pull-requests: write
+  contents: write       # write to allow creating Releases
+  pull-requests: write  # So we can write comments from the workflow
 
 jobs:
+    # Run the gradle build - 
+    # this job handles all the work related to the outputs of the gradle build,
+    # so we don't have to pass large files between jobs.
     build:
         runs-on: ubuntu-latest
 
         steps:
           - uses: actions/checkout@v4
 
-          - name: Set up JDK 17
+          # Setup Java
+          - name: set up JDK 17
             uses: actions/setup-java@v4
             with:
               java-version: '17'
               distribution: 'zulu'
 
+          # Setup Gradle with build caching (caches build outputs, not just downloaded dependencies)
           - name: Setup Gradle
             uses: gradle/actions/setup-gradle@v4
             with:
               cache-read-only: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
 
-          - name: Build debug APK
+          # Build test apk
+          - name: Run CLI - Build
+            shell: bash
             run: ./gradlew assembleDebug --no-daemon --build-cache
 
+          # Set time we can timestamp messages
           - name: Set current time
             run: |
               echo "CURRENT_TIME=$(TZ='Europe/Amsterdam' date +'%d/%m/%Y %H:%M:%S')" >> $GITHUB_ENV
+              # We create a safe tag name using the unique PR number and GitHub run attempt
+              echo "RELEASE_TAG=pr-${{ github.event.pull_request.number || 'manual' }}-build-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
           - name: Generate Release Tag
             id: generate-tag
             run: |
+              # Use head_ref for PRs, fallback to ref_name for manual dispatches
               RAW_BRANCH="${{ github.head_ref || github.ref_name }}"
+              
+              # Replace slashes and special characters with dashes, convert to lowercase
               CLEAN_BRANCH=$(echo "$RAW_BRANCH" | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
+
+              # Combine branch name with run identifiers
               TAG_NAME="${CLEAN_BRANCH}-${{ github.run_number }}-${{ github.run_attempt }}"
+              
               echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
 
+          # Create a unique GitHub Release and upload the APK
           - name: Create Release and Upload APK
             id: create-release
             uses: ncipollo/release-action@v1
@@ -61,13 +79,13 @@ jobs:
               prerelease: true
               draft: false
 
+          # Write a comment on the PR with the direct download link to the release asset
           - name: Write Example APK comment
-            if: github.event_name == 'pull_request'
             uses: marocchino/sticky-pull-request-comment@v3
             with:
               header: example-app-link
               message: |
-                App apk at:
+                App apk at: 
                 https://github.com/${{ github.repository }}/releases/download/${{ steps.generate-tag.outputs.tag }}/app-debug.apk
 
                 * **Triggered by:** PR Commit `${{ github.sha }}`

--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -1,63 +1,55 @@
 name: On Pull Request
 
 on:
-    workflow_call: # Makes sure this job can be acted.
+    workflow_call:
     workflow_dispatch: {}
     pull_request:
         branches:
-            # The following branches are worth running the checks on
             - main
+
+# Cancel in-progress runs for the same PR/branch — only the latest push matters
+concurrency:
+  group: build-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   id-token: write
-  contents: write       # write to allow creating Releases
-  pull-requests: write  # So we can write comments from the workflow
+  contents: write
+  pull-requests: write
 
 jobs:
-    # Run the gradle build - 
-    # this job handles all the work related to the outputs of the gradle build,
-    # so we don't have to pass large files between jobs.
     build:
         runs-on: ubuntu-latest
 
         steps:
           - uses: actions/checkout@v4
 
-          # Setup Java
-          - name: set up JDK 17
+          - name: Set up JDK 17
             uses: actions/setup-java@v4
             with:
               java-version: '17'
               distribution: 'zulu'
-              cache: 'gradle' # Automatically cache build dependencies
 
-          # Build test apk
-          - name: Run CLI - Build
-            shell: bash
-            run: ./gradlew assembleDebug
+          - name: Setup Gradle
+            uses: gradle/actions/setup-gradle@v4
+            with:
+              cache-read-only: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
 
-          # Set time we can timestamp messages
+          - name: Build debug APK
+            run: ./gradlew assembleDebug --no-daemon --build-cache
+
           - name: Set current time
             run: |
               echo "CURRENT_TIME=$(TZ='Europe/Amsterdam' date +'%d/%m/%Y %H:%M:%S')" >> $GITHUB_ENV
-              # We create a safe tag name using the unique PR number and GitHub run attempt
-              echo "RELEASE_TAG=pr-${{ github.event.pull_request.number || 'manual' }}-build-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
           - name: Generate Release Tag
             id: generate-tag
             run: |
-              # Use head_ref for PRs, fallback to ref_name for manual dispatches
               RAW_BRANCH="${{ github.head_ref || github.ref_name }}"
-              
-              # Replace slashes and special characters with dashes, convert to lowercase
               CLEAN_BRANCH=$(echo "$RAW_BRANCH" | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
-
-              # Combine branch name with run identifiers
               TAG_NAME="${CLEAN_BRANCH}-${{ github.run_number }}-${{ github.run_attempt }}"
-              
               echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
 
-          # Create a unique GitHub Release and upload the APK
           - name: Create Release and Upload APK
             id: create-release
             uses: ncipollo/release-action@v1
@@ -69,13 +61,13 @@ jobs:
               prerelease: true
               draft: false
 
-          # Write a comment on the PR with the direct download link to the release asset
           - name: Write Example APK comment
+            if: github.event_name == 'pull_request'
             uses: marocchino/sticky-pull-request-comment@v3
             with:
               header: example-app-link
               message: |
-                App apk at: 
+                App apk at:
                 https://github.com/${{ github.repository }}/releases/download/${{ steps.generate-tag.outputs.tag }}/app-debug.apk
 
                 * **Triggered by:** PR Commit `${{ github.sha }}`

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,15 @@
 # any settings specified in this file.
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+
+# JVM memory settings - 4GB heap for faster compilation on CI
+org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m
+
+# Build parallelism and caching
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -21,3 +23,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Kotlin incremental compilation
+kotlin.incremental=true


### PR DESCRIPTION
- Enable Gradle parallel execution, build cache, and configuration cache
- Increase JVM heap to 4GB with parallel GC for faster compilation
- Switch to gradle/actions/setup-gradle@v4 for smarter dependency and
  build caching (caches build outputs, not just downloaded dependencies)
- Add concurrency group to cancel superseded PR builds
- Use --no-daemon to avoid daemon startup overhead on ephemeral CI runners
- Skip PR comment step on non-PR triggers (workflow_dispatch)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NzvcfAFmpTwshsowgZyhtM