### PR TITLE
Redesign video review page to match record page layout

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -139,6 +139,7 @@ object KoinModule {
         viewModel {
             RecordVideoViewModel(
                 settingsDao = get(),
+                videoResolutionRepository = get(),
             )
         }
         viewModel { (date: LocalDate, videoContentUri: Uri) ->

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/glass/GlassComponents.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/glass/GlassComponents.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -122,7 +123,6 @@ fun GlassRecordButton(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .size(76.dp)
             .alpha(if (enabled) 1f else 0.4f)
             .clip(CircleShape)
             .background(GlassFill, CircleShape)
@@ -130,10 +130,10 @@ fun GlassRecordButton(
             .clickable(enabled = enabled, onClick = onClick),
     ) {
         val innerShape = if (isRecording) RoundedCornerShape(8.dp) else CircleShape
-        val innerSize = if (isRecording) 28.dp else 60.dp
+        val innerFraction = if (isRecording) 0.37f else 0.79f
         Box(
             modifier = Modifier
-                .size(innerSize)
+                .fillMaxSize(innerFraction)
                 .background(AccentRecord, innerShape)
         )
     }
@@ -148,7 +148,6 @@ fun GlassAcceptButton(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .size(76.dp)
             .alpha(if (enabled) 1f else 0.4f)
             .clip(CircleShape)
             .background(GlassFill, CircleShape)
@@ -158,14 +157,14 @@ fun GlassAcceptButton(
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
-                .size(60.dp)
+                .fillMaxSize(0.79f)
                 .background(AccentAccept, CircleShape)
         ) {
             Image(
                 painter = painterResource(R.drawable.tick),
                 contentDescription = "Accept",
                 colorFilter = ColorFilter.tint(Color.White),
-                modifier = Modifier.size(32.dp),
+                modifier = Modifier.fillMaxSize(0.53f),
             )
         }
     }
@@ -223,10 +222,12 @@ private fun PreviewGlassComponents() {
             GlassRecordButton(
                 isRecording = false,
                 onClick = {},
+                modifier = Modifier.size(76.dp),
             )
             GlassRecordButton(
                 isRecording = true,
                 onClick = {},
+                modifier = Modifier.size(76.dp),
             )
         }
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/glass/GlassComponents.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/glass/GlassComponents.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.R
+import com.lukeneedham.videodiary.ui.theme.AccentAccept
 import com.lukeneedham.videodiary.ui.theme.AccentRecord
 import com.lukeneedham.videodiary.ui.theme.GlassBorder
 import com.lukeneedham.videodiary.ui.theme.GlassFill
@@ -135,6 +136,38 @@ fun GlassRecordButton(
                 .size(innerSize)
                 .background(AccentRecord, innerShape)
         )
+    }
+}
+
+@Composable
+fun GlassAcceptButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .size(76.dp)
+            .alpha(if (enabled) 1f else 0.4f)
+            .clip(CircleShape)
+            .background(GlassFill, CircleShape)
+            .border(width = 3.dp, color = Color.White, shape = CircleShape)
+            .clickable(enabled = enabled, onClick = onClick),
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(60.dp)
+                .background(AccentAccept, CircleShape)
+        ) {
+            Image(
+                painter = painterResource(R.drawable.tick),
+                contentDescription = "Accept",
+                colorFilter = ColorFilter.tint(Color.White),
+                modifier = Modifier.size(32.dp),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -46,8 +46,8 @@ fun CheckVideoPageContent(
     ) {
         Box(
             modifier = Modifier
-                .weight(1f)
                 .fillMaxWidth()
+                .aspectRatio(videoAspectRatio ?: (9f / 16f))
         ) {
             if (videoAspectRatio != null) {
                 VideoPlayer(
@@ -77,10 +77,10 @@ fun CheckVideoPageContent(
 
         Box(
             modifier = Modifier
+                .weight(1f)
                 .fillMaxWidth()
                 .background(Color.Black)
                 .navigationBarsPadding()
-                .height(120.dp)
                 .padding(horizontal = 16.dp)
         ) {
             Row(

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -3,9 +3,12 @@ package com.lukeneedham.videodiary.ui.feature.record.check
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
@@ -17,12 +20,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.R
 import com.lukeneedham.videodiary.domain.model.Video
-import com.lukeneedham.videodiary.ui.feature.common.glass.BottomScrim
+import com.lukeneedham.videodiary.ui.feature.common.glass.GlassAcceptButton
 import com.lukeneedham.videodiary.ui.feature.common.glass.GlassIconButton
 import com.lukeneedham.videodiary.ui.feature.common.glass.TopScrim
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayer
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
-import com.lukeneedham.videodiary.ui.theme.AccentAccept
 
 @Composable
 fun CheckVideoPageContent(
@@ -37,16 +39,15 @@ fun CheckVideoPageContent(
             playingVideo = video
         }
     }
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
+    Column(
+        modifier = Modifier.fillMaxSize()
     ) {
-        if (videoAspectRatio != null) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.fillMaxSize()
-            ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+        ) {
+            if (videoAspectRatio != null) {
                 VideoPlayer(
                     video = video,
                     aspectRatio = videoAspectRatio,
@@ -54,64 +55,63 @@ fun CheckVideoPageContent(
                     modifier = Modifier.fillMaxSize(),
                 )
             }
-        }
 
-        TopScrim(
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .height(120.dp)
-        )
-        BottomScrim(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .height(160.dp)
-        )
-
-        GlassIconButton(
-            iconRes = R.drawable.close,
-            contentDescription = "Cancel",
-            onClick = onCancelClick,
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .safeDrawingPadding()
-                .padding(16.dp)
-        )
-
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .safeDrawingPadding()
-                .padding(bottom = 24.dp)
-        ) {
-            val muteIcon =
-                if (videoPlayerController.isVolumeOn) R.drawable.volume_on else R.drawable.volume_off
-            GlassIconButton(
-                iconRes = muteIcon,
-                contentDescription = "Toggle sound",
-                onClick = { videoPlayerController.toggleVolumeOn() },
+            TopScrim(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .height(140.dp)
             )
 
-            val isPlaying = !videoPlayerController.isTogglePaused
-            val playIcon = if (isPlaying) R.drawable.pause else R.drawable.play
             GlassIconButton(
-                iconRes = playIcon,
-                contentDescription = "Play/pause",
-                onClick = { videoPlayerController.toggleIsPlaying() },
+                iconRes = R.drawable.close,
+                contentDescription = "Cancel",
+                onClick = onCancelClick,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .safeDrawingPadding()
+                    .padding(16.dp)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.Black)
+                .navigationBarsPadding()
+                .padding(vertical = 24.dp, horizontal = 16.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
+                val muteIcon =
+                    if (videoPlayerController.isVolumeOn) R.drawable.volume_on else R.drawable.volume_off
+                GlassIconButton(
+                    iconRes = muteIcon,
+                    contentDescription = "Toggle sound",
+                    onClick = { videoPlayerController.toggleVolumeOn() },
+                )
+
+                val isPlaying = !videoPlayerController.isTogglePaused
+                val playIcon = if (isPlaying) R.drawable.pause else R.drawable.play
+                GlassIconButton(
+                    iconRes = playIcon,
+                    contentDescription = "Play/pause",
+                    onClick = { videoPlayerController.toggleIsPlaying() },
+                )
+            }
+
+            GlassAcceptButton(
+                onClick = onAccepted,
+                modifier = Modifier.align(Alignment.Center)
             )
 
             GlassIconButton(
                 iconRes = R.drawable.retake,
                 contentDescription = "Retake",
                 onClick = onRetakeClick,
-            )
-
-            GlassIconButton(
-                iconRes = R.drawable.tick,
-                contentDescription = "Accept",
-                tint = AccentAccept,
-                onClick = onAccepted,
+                modifier = Modifier.align(Alignment.CenterEnd)
             )
         }
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -44,35 +44,35 @@ fun CheckVideoPageContent(
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(videoAspectRatio ?: (9f / 16f))
-        ) {
-            if (videoAspectRatio != null) {
+        if (videoAspectRatio != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(videoAspectRatio)
+            ) {
                 VideoPlayer(
                     video = video,
                     aspectRatio = videoAspectRatio,
                     controller = videoPlayerController,
                     modifier = Modifier.fillMaxSize(),
                 )
+
+                TopScrim(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .height(140.dp)
+                )
+
+                GlassIconButton(
+                    iconRes = R.drawable.close,
+                    contentDescription = "Cancel",
+                    onClick = onCancelClick,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .safeDrawingPadding()
+                        .padding(16.dp)
+                )
             }
-
-            TopScrim(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .height(140.dp)
-            )
-
-            GlassIconButton(
-                iconRes = R.drawable.close,
-                contentDescription = "Cancel",
-                onClick = onCancelClick,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .safeDrawingPadding()
-                    .padding(16.dp)
-            )
         }
 
         Box(

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -78,7 +80,8 @@ fun CheckVideoPageContent(
                 .fillMaxWidth()
                 .background(Color.Black)
                 .navigationBarsPadding()
-                .padding(vertical = 24.dp, horizontal = 16.dp)
+                .height(120.dp)
+                .padding(horizontal = 16.dp)
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -104,7 +107,11 @@ fun CheckVideoPageContent(
 
             GlassAcceptButton(
                 onClick = onAccepted,
-                modifier = Modifier.align(Alignment.Center)
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(vertical = 10.dp)
+                    .fillMaxHeight()
+                    .aspectRatio(1f)
             )
 
             GlassIconButton(

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPage.kt
@@ -35,11 +35,13 @@ fun RecordVideoPage(
     ) {
         val qualityLocal = quality
         val videoDurationMillis = viewModel.videoDurationMillis
-        if (qualityLocal != null && resolution != null && videoDurationMillis != null) {
+        val videoAspectRatio = viewModel.videoAspectRatio
+        if (qualityLocal != null && resolution != null && videoDurationMillis != null && videoAspectRatio != null) {
             RecordVideoPageContent(
                 videoDurationMillis = videoDurationMillis,
                 quality = qualityLocal,
                 resolution = resolution,
+                videoAspectRatio = videoAspectRatio,
                 onRecordingFinished = onRecordingFinished,
                 onBack = onBack,
             )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
@@ -44,6 +44,7 @@ fun RecordVideoPageContent(
     videoDurationMillis: Long,
     resolution: Size,
     quality: Quality,
+    videoAspectRatio: Float,
     onRecordingFinished: (videoContentUri: Uri) -> Unit,
     onBack: () -> Unit,
 ) {
@@ -106,7 +107,7 @@ fun RecordVideoPageContent(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(resolution.width.toFloat() / resolution.height.toFloat())
+                .aspectRatio(videoAspectRatio)
         ) {
             CameraInput(
                 currentResolution = resolution,
@@ -179,6 +180,7 @@ internal fun PreviewRecordVideoPage() {
     RecordVideoPageContent(
         quality = Quality.HD,
         resolution = Size(100, 300),
+        videoAspectRatio = 100f / 300f,
         onRecordingFinished = {},
         videoDurationMillis = 3000,
         onBack = {},

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
@@ -105,8 +105,8 @@ fun RecordVideoPageContent(
     ) {
         Box(
             modifier = Modifier
-                .weight(1f)
                 .fillMaxWidth()
+                .aspectRatio(resolution.width.toFloat() / resolution.height.toFloat())
         ) {
             CameraInput(
                 currentResolution = resolution,
@@ -140,10 +140,10 @@ fun RecordVideoPageContent(
         Box(
             contentAlignment = Alignment.Center,
             modifier = Modifier
+                .weight(1f)
                 .fillMaxWidth()
                 .background(Color.Black)
                 .navigationBarsPadding()
-                .height(120.dp)
         ) {
             val centerButtonModifier = Modifier
                 .padding(vertical = 10.dp)

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
@@ -9,6 +9,8 @@ import androidx.camera.video.VideoCapture
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -141,8 +143,12 @@ fun RecordVideoPageContent(
                 .fillMaxWidth()
                 .background(Color.Black)
                 .navigationBarsPadding()
-                .padding(vertical = 24.dp)
+                .height(120.dp)
         ) {
+            val centerButtonModifier = Modifier
+                .padding(vertical = 10.dp)
+                .fillMaxHeight()
+                .aspectRatio(1f)
             if (currentState is RecordingState.Recording) {
                 val remainingSeconds = ((videoDurationMillis - currentState.duration.inWholeMilliseconds) / 1000.0)
                     .coerceAtLeast(0.0)
@@ -153,12 +159,14 @@ fun RecordVideoPageContent(
                         videoRecorder.cancelRecording()
                         state = RecordingState.Ready
                     },
+                    modifier = centerButtonModifier,
                 )
             } else {
                 GlassRecordButton(
                     isRecording = false,
                     enabled = currentState == RecordingState.Ready,
                     onClick = { record() },
+                    modifier = centerButtonModifier,
                 )
             }
         }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoViewModel.kt
@@ -7,15 +7,20 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lukeneedham.videodiary.data.persistence.SettingsDao
+import com.lukeneedham.videodiary.data.repository.VideoResolutionRepository
 import kotlinx.coroutines.launch
 
 class RecordVideoViewModel(
     private val settingsDao: SettingsDao,
+    private val videoResolutionRepository: VideoResolutionRepository,
 ) : ViewModel() {
     var resolution: Size? by mutableStateOf(null)
         private set
 
     var videoDurationMillis: Long? by mutableStateOf(null)
+        private set
+
+    var videoAspectRatio: Float? by mutableStateOf(null)
         private set
 
     init {
@@ -25,6 +30,10 @@ class RecordVideoViewModel(
 
         viewModelScope.launch {
             videoDurationMillis = settingsDao.getVideoDuration()?.inWholeMilliseconds
+        }
+
+        viewModelScope.launch {
+            videoAspectRatio = videoResolutionRepository.getAspectRatio()
         }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/component/RecordingCountdownButton.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/component/RecordingCountdownButton.kt
@@ -29,7 +29,6 @@ fun RecordingCountdownButton(
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .size(76.dp)
             .clip(CircleShape)
             .background(AccentRecord, CircleShape)
             .border(width = 3.dp, color = Color.White, shape = CircleShape)


### PR DESCRIPTION
Restructure CheckVideoPageContent from a full-bleed overlay design to a
Column layout with video aligned to top and a solid black bottom bar.
Add GlassAcceptButton (76dp green circle with tick icon) centered in
the bottom bar, with mute/pause buttons on the left and retake on
the right.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WmpbduuMqQxfP6NW9Xp8S3