### PR TITLE
Fix flash when navigating to video review page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .externalNativeBuild
 .cxx
 local.properties
+.kotlin

--- a/TODO.md
+++ b/TODO.md
@@ -2,5 +2,4 @@
 This is an ordered list of todo items. Each item should be done in isolation, and a separate PR opened for each item. Items must be done in order. When an item is done, the PR should include the original TODO text in the description, and the todo should be removed from this list. When asked to implement the top todo item, you always take just the top item.
 
 # Todos
-- fix the flash when navigating from the record page to the video review page - it flashes with the "confirm" button being enormous, because the video isnt rendering yet (so 0 height)
 - when a video is recording, show a slider on the left hand side to control brightness, and a slider on the right hand side to control zoom

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPage.kt
@@ -1,6 +1,11 @@
 package com.lukeneedham.videodiary.ui.feature.record.check
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 @Composable
 fun CheckVideoPage(
@@ -9,14 +14,23 @@ fun CheckVideoPage(
     onRetakeClick: () -> Unit,
     onAccepted: () -> Unit,
 ) {
-    CheckVideoPageContent(
-        onCancelClick = onCancelClick,
-        onRetakeClick = onRetakeClick,
-        onAccepted = {
-            viewModel.acceptVideo()
-            onAccepted()
-        },
-        video = viewModel.video,
-        videoAspectRatio = viewModel.videoAspectRatio,
-    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.Black)
+    ) {
+        val videoAspectRatio = viewModel.videoAspectRatio
+        if (videoAspectRatio != null) {
+            CheckVideoPageContent(
+                onCancelClick = onCancelClick,
+                onRetakeClick = onRetakeClick,
+                onAccepted = {
+                    viewModel.acceptVideo()
+                    onAccepted()
+                },
+                video = viewModel.video,
+                videoAspectRatio = videoAspectRatio,
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -31,7 +31,7 @@ import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerContr
 @Composable
 fun CheckVideoPageContent(
     video: Video,
-    videoAspectRatio: Float?,
+    videoAspectRatio: Float,
     onCancelClick: () -> Unit,
     onRetakeClick: () -> Unit,
     onAccepted: () -> Unit,
@@ -44,35 +44,33 @@ fun CheckVideoPageContent(
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
-        if (videoAspectRatio != null) {
-            Box(
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(videoAspectRatio)
+        ) {
+            VideoPlayer(
+                video = video,
+                aspectRatio = videoAspectRatio,
+                controller = videoPlayerController,
+                modifier = Modifier.fillMaxSize(),
+            )
+
+            TopScrim(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(videoAspectRatio)
-            ) {
-                VideoPlayer(
-                    video = video,
-                    aspectRatio = videoAspectRatio,
-                    controller = videoPlayerController,
-                    modifier = Modifier.fillMaxSize(),
-                )
+                    .align(Alignment.TopCenter)
+                    .height(140.dp)
+            )
 
-                TopScrim(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .height(140.dp)
-                )
-
-                GlassIconButton(
-                    iconRes = R.drawable.close,
-                    contentDescription = "Cancel",
-                    onClick = onCancelClick,
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .safeDrawingPadding()
-                        .padding(16.dp)
-                )
-            }
+            GlassIconButton(
+                iconRes = R.drawable.close,
+                contentDescription = "Cancel",
+                onClick = onCancelClick,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .safeDrawingPadding()
+                    .padding(16.dp)
+            )
         }
 
         Box(


### PR DESCRIPTION
## Summary

- Fix the layout flash when navigating from the record page to the video review page, where the confirm button appeared enormous because the video wasn't rendering yet (0 height)
- Defer rendering `CheckVideoPageContent` until `videoAspectRatio` is loaded, showing a black screen in the interim — matching the pattern already used by `RecordVideoPage`
- Change `CheckVideoPageContent.videoAspectRatio` from `Float?` to `Float` since the null case is now handled by the parent

## Original TODO

> fix the flash when navigating from the record page to the video review page - it flashes with the "confirm" button being enormous, because the video isnt rendering yet (so 0 height)

## Root cause

`CheckVideoViewModel` loads `videoAspectRatio` asynchronously. Before it resolved, `CheckVideoPageContent` skipped rendering the video `Box` (guarded by `if (videoAspectRatio != null)`), so the bottom bar with `.weight(1f)` claimed all vertical space, and `GlassAcceptButton` with `.fillMaxHeight().aspectRatio(1f)` expanded to fill it.

## Test plan

- [ ] Navigate from the record page to the video review page and confirm there is no flash of an oversized confirm button
- [ ] Verify the video plays correctly on the review page
- [ ] Verify accept, retake, and cancel buttons all work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qexsuvuof3cj4cBxwy32vd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qexsuvuof3cj4cBxwy32vd)_