### PR TITLE
Redesign date picker dialog top bar and remove day card month text

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,5 @@
 This is an ordered list of todo items. Each item should be done in isolation, and a separate PR opened for each item. Items must be done in order. When an item is done, the PR should include the original TODO text in the description, and the todo should be removed from this list. When asked to implement the top todo item, you always take just the top item.
 
 # Todos
-- change the date picker - introduce a top bar to the dialog. move the close button to an X icon in the right of the top bar. centered in the topbar is the name of the month of the first date currently visible in the picker. remove the month text in the date picker day card for the first date of the month.
 - change the export page date pickers. in a single line it should read "export from X up to and including Y", where X and Y are filled with dates, and are clickable, and open the date picker when clicked. to make clear they are clickable they should be inside buttons with a background
 - after exporting a video, give the user the option to give it a name and save it in the app. there will be a new page, export catalogue, where the user can see all their saved exports again.

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,6 +28,8 @@ import com.lukeneedham.videodiary.domain.model.Day
 import com.lukeneedham.videodiary.ui.theme.Typography
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
 fun DiaryDatePicker(
@@ -34,6 +37,7 @@ fun DiaryDatePicker(
     weeks: List<List<Day>>,
     videoAspectRatio: Float,
     onDateSelected: (LocalDate) -> Unit,
+    onFirstVisibleMonthChanged: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val weekDays = weeks.map { week ->
@@ -57,9 +61,10 @@ fun DiaryDatePicker(
             if (!isCurrentWeek && isEmpty) {
                 val previous = lastOrNull()
                 if (previous is WeekRow.Collapsed) {
-                    this[lastIndex] = WeekRow.Collapsed(previous.weekCount + 1)
+                    this[lastIndex] = WeekRow.Collapsed(previous.weekCount + 1, previous.firstDate)
                 } else {
-                    add(WeekRow.Collapsed(weekCount = 1))
+                    val firstDate = week.filterIsInstance<Weekday.Value>().first().day.date
+                    add(WeekRow.Collapsed(weekCount = 1, firstDate = firstDate))
                 }
             } else {
                 add(WeekRow.Normal(week))
@@ -80,6 +85,28 @@ fun DiaryDatePicker(
 
     LaunchedEffect(firstVisibleWeekIndex) {
         state.scrollToItem(firstVisibleWeekIndex)
+    }
+
+    LaunchedEffect(rows) {
+        snapshotFlow { state.firstVisibleItemIndex }
+            .collect { index ->
+                if (index in rows.indices) {
+                    val monthName = when (val row = rows[index]) {
+                        is WeekRow.Normal -> {
+                            row.week.filterIsInstance<Weekday.Value>()
+                                .firstOrNull()?.day?.date?.month
+                                ?.getDisplayName(TextStyle.FULL, Locale.getDefault())
+                        }
+                        is WeekRow.Collapsed -> {
+                            row.firstDate.month
+                                .getDisplayName(TextStyle.FULL, Locale.getDefault())
+                        }
+                    }
+                    if (monthName != null) {
+                        onFirstVisibleMonthChanged(monthName)
+                    }
+                }
+            }
     }
 
     LazyColumn(
@@ -172,7 +199,7 @@ private sealed interface Weekday {
 
 private sealed interface WeekRow {
     data class Normal(val week: List<Weekday>) : WeekRow
-    data class Collapsed(val weekCount: Int) : WeekRow
+    data class Collapsed(val weekCount: Int, val firstDate: LocalDate) : WeekRow
 }
 
 @Preview
@@ -183,5 +210,6 @@ private fun Preview() {
         weeks = MockDataDiaryDatePicker.weeks,
         videoAspectRatio = MockDataDiaryDatePicker.videoAspectRatio,
         onDateSelected = {},
+        onFirstVisibleMonthChanged = {},
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePicker.kt
@@ -37,7 +37,7 @@ fun DiaryDatePicker(
     weeks: List<List<Day>>,
     videoAspectRatio: Float,
     onDateSelected: (LocalDate) -> Unit,
-    onFirstVisibleMonthChanged: (String) -> Unit,
+    onFirstVisibleMonthChanged: (monthName: String, year: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val weekDays = weeks.map { week ->
@@ -91,19 +91,18 @@ fun DiaryDatePicker(
         snapshotFlow { state.firstVisibleItemIndex }
             .collect { index ->
                 if (index in rows.indices) {
-                    val monthName = when (val row = rows[index]) {
+                    val date = when (val row = rows[index]) {
                         is WeekRow.Normal -> {
                             row.week.filterIsInstance<Weekday.Value>()
-                                .firstOrNull()?.day?.date?.month
-                                ?.getDisplayName(TextStyle.FULL, Locale.getDefault())
+                                .firstOrNull()?.day?.date
                         }
-                        is WeekRow.Collapsed -> {
-                            row.firstDate.month
-                                .getDisplayName(TextStyle.FULL, Locale.getDefault())
-                        }
+                        is WeekRow.Collapsed -> row.firstDate
                     }
-                    if (monthName != null) {
-                        onFirstVisibleMonthChanged(monthName)
+                    if (date != null) {
+                        val monthName = date.month.getDisplayName(
+                            TextStyle.FULL, Locale.getDefault()
+                        )
+                        onFirstVisibleMonthChanged(monthName, date.year.toString())
                     }
                 }
             }
@@ -210,6 +209,6 @@ private fun Preview() {
         weeks = MockDataDiaryDatePicker.weeks,
         videoAspectRatio = MockDataDiaryDatePicker.videoAspectRatio,
         onDateSelected = {},
-        onFirstVisibleMonthChanged = {},
+        onFirstVisibleMonthChanged = { _, _ -> },
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDay.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDay.kt
@@ -28,8 +28,6 @@ import com.lukeneedham.videodiary.domain.model.Day
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.time.format.TextStyle
-import java.util.Locale
 
 @Composable
 fun DiaryDatePickerDay(
@@ -62,17 +60,6 @@ fun DiaryDatePickerDay(
                 fontWeight = FontWeight.Bold,
                 fontSize = 10.sp,
             )
-            val isFirstDayOfMonth = date.dayOfMonth == 1
-            if (isFirstDayOfMonth) {
-                Text(
-                    text = date.month.getDisplayName(
-                        TextStyle.SHORT,
-                        Locale.getDefault()
-                    ),
-                    color = Color.White,
-                    fontSize = 7.sp,
-                )
-            }
             val isFirstDayOfYear = date.dayOfYear == 1
             if (isFirstDayOfYear) {
                 Text(

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -58,7 +59,8 @@ fun DiaryDatePickerDialog(
             modifier = Modifier
                 .fillMaxWidth(0.9f)
                 .fillMaxHeight(0.6f)
-                .background(color = Color.White, shape = RoundedCornerShape(10.dp))
+                .clip(RoundedCornerShape(10.dp))
+                .background(color = Color.White)
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
@@ -25,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.koin.compose.koinInject
@@ -44,6 +46,7 @@ fun DiaryDatePickerDialog(
     }
 
     var topBarMonthName by remember { mutableStateOf("") }
+    var topBarYear by remember { mutableStateOf("") }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -62,20 +65,29 @@ fun DiaryDatePickerDialog(
                     .fillMaxWidth()
                     .padding(4.dp)
             ) {
-                Text(
-                    text = topBarMonthName,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.align(Alignment.Center)
-                )
                 Icon(
                     imageVector = Icons.Default.Close,
                     contentDescription = "Close",
                     modifier = Modifier
-                        .align(Alignment.CenterEnd)
+                        .align(Alignment.CenterStart)
                         .clickable { onDismiss() }
                         .padding(8.dp)
                 )
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.align(Alignment.Center)
+                ) {
+                    Text(
+                        text = topBarMonthName,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = topBarYear,
+                        fontSize = 12.sp,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
             val videoAspectRatio = viewModel.videoAspectRatio
             if (videoAspectRatio != null) {
@@ -87,7 +99,10 @@ fun DiaryDatePickerDialog(
                         onDateSelected(it)
                         onDismiss()
                     },
-                    onFirstVisibleMonthChanged = { topBarMonthName = it },
+                    onFirstVisibleMonthChanged = { monthName, year ->
+                        topBarMonthName = monthName
+                        topBarYear = year
+                    },
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
@@ -95,6 +110,7 @@ fun DiaryDatePickerDialog(
             } else {
                 Spacer(modifier = Modifier.weight(1f))
             }
+            Spacer(modifier = Modifier.height(2.dp))
         }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
@@ -58,7 +58,9 @@ fun DiaryDatePickerDialog(
             modifier = Modifier
                 .fillMaxWidth(0.9f)
                 .fillMaxHeight(0.6f)
-                .background(color = Color.White, shape = RoundedCornerShape(10.dp))
+                .clip(RoundedCornerShape(10.dp))
+                .background(color = Color.White)
+                .padding(bottom = 2.dp)
         ) {
             Box(
                 modifier = Modifier
@@ -106,8 +108,6 @@ fun DiaryDatePickerDialog(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
-                        .padding(bottom = 2.dp)
-                        .clip(RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp))
                 )
             } else {
                 Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
@@ -59,8 +58,7 @@ fun DiaryDatePickerDialog(
             modifier = Modifier
                 .fillMaxWidth(0.9f)
                 .fillMaxHeight(0.6f)
-                .clip(RoundedCornerShape(10.dp))
-                .background(color = Color.White)
+                .background(color = Color.White, shape = RoundedCornerShape(10.dp))
         ) {
             Box(
                 modifier = Modifier
@@ -108,11 +106,12 @@ fun DiaryDatePickerDialog(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
+                        .padding(bottom = 2.dp)
+                        .clip(RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp))
                 )
             } else {
                 Spacer(modifier = Modifier.weight(1f))
             }
-            Spacer(modifier = Modifier.height(2.dp))
         }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/datepicker/DiaryDatePickerDialog.kt
@@ -7,15 +7,22 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -36,6 +43,8 @@ fun DiaryDatePickerDialog(
         }
     }
 
+    var topBarMonthName by remember { mutableStateOf("") }
+
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
@@ -48,7 +57,26 @@ fun DiaryDatePickerDialog(
                 .fillMaxHeight(0.6f)
                 .background(color = Color.White, shape = RoundedCornerShape(10.dp))
         ) {
-            Spacer(modifier = Modifier.height(10.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(4.dp)
+            ) {
+                Text(
+                    text = topBarMonthName,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close",
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .clickable { onDismiss() }
+                        .padding(8.dp)
+                )
+            }
             val videoAspectRatio = viewModel.videoAspectRatio
             if (videoAspectRatio != null) {
                 DiaryDatePicker(
@@ -59,6 +87,7 @@ fun DiaryDatePickerDialog(
                         onDateSelected(it)
                         onDismiss()
                     },
+                    onFirstVisibleMonthChanged = { topBarMonthName = it },
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
@@ -66,22 +95,6 @@ fun DiaryDatePickerDialog(
             } else {
                 Spacer(modifier = Modifier.weight(1f))
             }
-            Spacer(modifier = Modifier.height(5.dp))
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.9f)
-                    .height(1.dp)
-                    .background(color = Color.Black.copy(alpha = 0.5f))
-                    .align(Alignment.CenterHorizontally)
-            )
-            Text(
-                text = "Close",
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { onDismiss() }
-                    .padding(vertical = 20.dp)
-            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace the bottom "Close" button with a top bar containing a close (X) icon on the left, the current month name centered, and the year in small text below
- The month/year updates dynamically as the user scrolls through the date picker
- Remove the month text from day cards for the first day of each month (now shown in the top bar)
- Add bottom padding to the dialog matching the horizontal padding for a consistent white border

## Original TODO
> change the date picker - introduce a top bar to the dialog. move the close button to an X icon in the right of the top bar. centered in the topbar is the name of the month of the first date currently visible in the picker. remove the month text in the date picker day card for the first date of the month.

## Test plan
- [ ] Open the date picker from the calendar page and verify the top bar shows month name and year
- [ ] Scroll through dates and confirm the month/year updates as different months become visible
- [ ] Verify the X close icon is on the top-left and dismisses the dialog
- [ ] Confirm day cards no longer show month text on the 1st of each month
- [ ] Verify there is a white border below the last row of dates
- [ ] Open the date picker from the export page and verify the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtMguNAegwnKuS5BT9MwqW