### PR TITLE
Redesign export page date pickers as inline sentence

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,5 @@
 This is an ordered list of todo items. Each item should be done in isolation, and a separate PR opened for each item. Items must be done in order. When an item is done, the PR should include the original TODO text in the description, and the todo should be removed from this list. When asked to implement the top todo item, you always take just the top item.
 
 # Todos
-- change the export page date pickers. in a single line it should read "export from X up to and including Y", where X and Y are filled with dates, and are clickable, and open the date picker when clicked. to make clear they are clickable they should be inside buttons with a background
 - make the app reactive to the current date. if the current date changes while the app is active, the user wont be able to see the current day until they restart the app - fix this
 - after exporting a video, give the user the option to give it a name and save it in the app. there will be a new page, export catalogue, where the user can see all their saved exports again.

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageReady.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageReady.kt
@@ -2,8 +2,6 @@ package com.lukeneedham.videodiary.ui.feature.exportdiary.create
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxDefaults
@@ -25,9 +24,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import com.lukeneedham.videodiary.ui.feature.common.Button
 import com.lukeneedham.videodiary.ui.feature.common.datepicker.DiaryDatePickerDialog
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.component.ExportDiaryCreateDatePicker
@@ -36,7 +40,6 @@ import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportStat
 import com.lukeneedham.videodiary.ui.theme.Typography
 import java.time.LocalDate
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ExportDiaryCreatePageReady(
     totalVideoCount: Int,
@@ -76,34 +79,48 @@ fun ExportDiaryCreatePageReady(
                             .weight(1f)
                             .verticalScroll(rememberScrollState())
                     ) {
-                        FlowRow(
-                            verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
-                        ) {
-                            Text(
-                                text = "Export from ",
-                                color = Color.Black,
-                                fontSize = Typography.Size.small,
-                                modifier = Modifier.align(Alignment.CenterVertically),
-                            )
-                            ExportDiaryCreateDatePicker(
-                                date = exportStartDate,
-                                onClick = {
-                                    showStartDatePicker = true
-                                },
-                            )
-                            Text(
-                                text = " up to and including ",
-                                color = Color.Black,
-                                fontSize = Typography.Size.small,
-                                modifier = Modifier.align(Alignment.CenterVertically),
-                            )
-                            ExportDiaryCreateDatePicker(
-                                date = exportEndDate,
-                                onClick = {
-                                    showEndDatePicker = true
-                                },
-                            )
+                        val startDateId = "startDate"
+                        val endDateId = "endDate"
+
+                        val annotatedString = buildAnnotatedString {
+                            append("Export from ")
+                            appendInlineContent(startDateId)
+                            append(" up to and including ")
+                            appendInlineContent(endDateId)
                         }
+
+                        val datePlaceholder = Placeholder(
+                            width = 7.5.em,
+                            height = 2.em,
+                            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                        )
+
+                        val inlineContent = mapOf(
+                            startDateId to androidx.compose.foundation.text.InlineTextContent(
+                                placeholder = datePlaceholder,
+                            ) {
+                                ExportDiaryCreateDatePicker(
+                                    date = exportStartDate,
+                                    onClick = { showStartDatePicker = true },
+                                )
+                            },
+                            endDateId to androidx.compose.foundation.text.InlineTextContent(
+                                placeholder = datePlaceholder,
+                            ) {
+                                ExportDiaryCreateDatePicker(
+                                    date = exportEndDate,
+                                    onClick = { showEndDatePicker = true },
+                                )
+                            },
+                        )
+
+                        Text(
+                            text = annotatedString,
+                            inlineContent = inlineContent,
+                            color = Color.Black,
+                            fontSize = Typography.Size.small,
+                            lineHeight = 44.sp,
+                        )
 
                         Spacer(modifier = Modifier.height(30.dp))
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageReady.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageReady.kt
@@ -2,6 +2,8 @@ package com.lukeneedham.videodiary.ui.feature.exportdiary.create
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,6 +36,7 @@ import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportStat
 import com.lukeneedham.videodiary.ui.theme.Typography
 import java.time.LocalDate
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ExportDiaryCreatePageReady(
     totalVideoCount: Int,
@@ -73,30 +76,34 @@ fun ExportDiaryCreatePageReady(
                             .weight(1f)
                             .verticalScroll(rememberScrollState())
                     ) {
-                        Text(
-                            text = "Export will include videos...",
-                            color = Color.Black,
-                            fontSize = Typography.Size.small,
-                        )
-                        Spacer(modifier = Modifier.height(20.dp))
-
-                        ExportDiaryCreateDatePicker(
-                            date = exportStartDate,
-                            label = "From",
-                            onChange = {
-                                showStartDatePicker = true
-                            },
-                        )
-
-                        Spacer(modifier = Modifier.height(20.dp))
-
-                        ExportDiaryCreateDatePicker(
-                            date = exportEndDate,
-                            label = "To",
-                            onChange = {
-                                showEndDatePicker = true
-                            },
-                        )
+                        FlowRow(
+                            verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+                        ) {
+                            Text(
+                                text = "Export from ",
+                                color = Color.Black,
+                                fontSize = Typography.Size.small,
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                            )
+                            ExportDiaryCreateDatePicker(
+                                date = exportStartDate,
+                                onClick = {
+                                    showStartDatePicker = true
+                                },
+                            )
+                            Text(
+                                text = " up to and including ",
+                                color = Color.Black,
+                                fontSize = Typography.Size.small,
+                                modifier = Modifier.align(Alignment.CenterVertically),
+                            )
+                            ExportDiaryCreateDatePicker(
+                                date = exportEndDate,
+                                onClick = {
+                                    showEndDatePicker = true
+                                },
+                            )
+                        }
 
                         Spacer(modifier = Modifier.height(30.dp))
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/component/ExportDiaryCreateDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/component/ExportDiaryCreateDatePicker.kt
@@ -1,20 +1,18 @@
 package com.lukeneedham.videodiary.ui.feature.exportdiary.create.component
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.domain.util.date.StandardDateTimeFormatter
-import com.lukeneedham.videodiary.ui.feature.common.Button
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.MockDataExportDiaryCreate
 import com.lukeneedham.videodiary.ui.theme.Typography
 import java.time.LocalDate
@@ -22,38 +20,23 @@ import java.time.LocalDate
 @Composable
 fun ExportDiaryCreateDatePicker(
     date: LocalDate,
-    label: String,
-    onChange: () -> Unit,
+    onClick: () -> Unit,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
+    val dateText = date.format(StandardDateTimeFormatter.date)
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .background(
+                color = Color.Black,
+                shape = RoundedCornerShape(10.dp),
+            )
+            .clickable { onClick() }
+            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
-        Column(
-            modifier = Modifier.weight(1f)
-        ) {
-            Text(
-                text = "$label:",
-                fontSize = Typography.Size.big,
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            val dateText = date.format(StandardDateTimeFormatter.date)
-            Text(
-                text = dateText,
-                fontSize = Typography.Size.small,
-            )
-            Text(
-                text = "(inclusive)",
-                fontSize = Typography.Size.extraSmall,
-            )
-        }
-
-        Button(
-            text = "Change",
-            onClick = {
-                onChange()
-            },
-            modifier = Modifier.weight(1f)
+        Text(
+            text = dateText,
+            color = Color.White,
+            fontSize = Typography.Size.small,
         )
     }
 }
@@ -63,7 +46,6 @@ fun ExportDiaryCreateDatePicker(
 internal fun PreviewExportDiaryDatePicker() {
     ExportDiaryCreateDatePicker(
         date = MockDataExportDiaryCreate.startDate,
-        label = "From",
-        onChange = {},
+        onClick = {},
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/component/ExportDiaryCreateDatePicker.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/component/ExportDiaryCreateDatePicker.kt
@@ -3,6 +3,7 @@ package com.lukeneedham.videodiary.ui.feature.exportdiary.create.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -26,12 +27,12 @@ fun ExportDiaryCreateDatePicker(
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
+            .fillMaxSize()
             .background(
                 color = Color.Black,
-                shape = RoundedCornerShape(10.dp),
+                shape = RoundedCornerShape(8.dp),
             )
             .clickable { onClick() }
-            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
         Text(
             text = dateText,


### PR DESCRIPTION
## Summary

- Replaces the separate "From" / "To" date picker rows with a single inline `FlowRow` reading **"Export from [date] up to and including [date]"**
- Each date is rendered as a clickable button with a black background and white text, making it visually clear they are interactive
- Simplifies `ExportDiaryCreateDatePicker` to a compact inline button component
- Removes the completed TODO item from `TODO.md`

## Original TODO

> change the export page date pickers. in a single line it should read "export from X up to and including Y", where X and Y are filled with dates, and are clickable, and open the date picker when clicked. to make clear they are clickable they should be inside buttons with a background

## Test plan

- [ ] Open the export diary page
- [ ] Verify the date range displays as "Export from [date] up to and including [date]" in a single flowing line
- [ ] Verify both date buttons have a black background with white text
- [ ] Tap each date button and confirm the date picker dialog opens
- [ ] Select new dates and confirm they update correctly
- [ ] Verify the layout wraps gracefully on narrow screens (FlowRow)
- [ ] Verify export functionality still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdRzErU1owtYYj8ocb2gyD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdRzErU1owtYYj8ocb2gyD)_