### PR TITLE
Add workflow to delete GitHub pre-releases

### DIFF
--- a/.github/workflows/delete_prereleases.yml
+++ b/.github/workflows/delete_prereleases.yml
@@ -1,0 +1,49 @@
+name: Delete Pre-releases
+
+on:
+  workflow_dispatch:
+
+jobs:
+  delete-prereleases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete all pre-releases
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let page = 1;
+            let deleted = 0;
+            while (true) {
+              const releases = await github.rest.repos.listReleases({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+                page: page,
+              });
+              if (releases.data.length === 0) break;
+              for (const release of releases.data) {
+                if (release.prerelease) {
+                  console.log(`Deleting pre-release: ${release.tag_name} (id: ${release.id})`);
+                  await github.rest.repos.deleteRelease({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    release_id: release.id,
+                  });
+                  try {
+                    await github.rest.git.deleteRef({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: `tags/${release.tag_name}`,
+                    });
+                    console.log(`Deleted tag: ${release.tag_name}`);
+                  } catch (e) {
+                    console.log(`Tag ${release.tag_name} may not exist: ${e.message}`);
+                  }
+                  deleted++;
+                }
+              }
+              page++;
+            }
+            console.log(`Total pre-releases deleted: ${deleted}`);


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`delete_prereleases.yml`) that can be manually triggered via `workflow_dispatch`
- When run, it deletes all pre-releases and their associated tags from the repository
- Useful for cleaning up CI-generated PR build releases that accumulate over time

## How to use
Go to **Actions > Delete Pre-releases > Run workflow** in the GitHub UI.

## Test plan
- [ ] Verify the workflow appears under the Actions tab
- [ ] Trigger it manually and confirm it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4xcnkhrUzn2gZxkinA43

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe4xcnkhrUzn2gZxkinA43)_