### PR TITLE
Make app reactive to current date changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,5 @@
 This is an ordered list of todo items. Each item should be done in isolation, and a separate PR opened for each item. When an item is done, the PR should include the original TODO text in the description, and the todo should be removed from this list.
 
 # Todos
-- make the app reactive to the current date. if the current date changes while the app is active, the user wont be able to see the current day until they restart the app - fix this
 - after exporting a video, give the user the option to give it a name and save it in the app. there will be a new page, export catalogue, where the user can see all their saved exports again.
 - improve onboarding flow - make beautiful, split across multiple pages, add page indicator at the bottom of each page so the user can see how far they are

--- a/app/src/main/java/com/lukeneedham/videodiary/data/repository/CalendarRepository.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/repository/CalendarRepository.kt
@@ -4,22 +4,25 @@ import com.lukeneedham.videodiary.data.mapper.VideoFileNameMapper
 import com.lukeneedham.videodiary.data.persistence.VideosDao
 import com.lukeneedham.videodiary.domain.model.Day
 import com.lukeneedham.videodiary.domain.util.date.CalendarUtil
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import java.time.LocalDate
 
 class CalendarRepository(
     private val videosDao: VideosDao,
     private val videoFileNameMapper: VideoFileNameMapper,
+    private val currentDateRepository: CurrentDateRepository,
 ) {
-    val allDays = videosDao.allVideos.map { allVideos ->
-        val today = LocalDate.now()
+    val allDays = combine(
+        videosDao.allVideos,
+        currentDateRepository.currentDate,
+    ) { allVideos, today ->
         val startDate =
             allVideos.minOfOrNull { videoFileNameMapper.nameToDate(it.name) } ?: today
-        getAllDays(startDate)
+        getAllDays(startDate, today)
     }
 
-    private fun getAllDays(startDate: LocalDate): List<Day> {
-        return getAllDates(startDate).map { date ->
+    private fun getAllDays(startDate: LocalDate, today: LocalDate): List<Day> {
+        return getAllDates(startDate, today).map { date ->
             val videoFile = videosDao.getVideoFileIfExists(date)
             val thumbnailFile = videosDao.getThumbnailFileIfExists(date)
             Day(date = date, videoFile = videoFile, thumbnailFile = thumbnailFile)
@@ -27,6 +30,6 @@ class CalendarRepository(
     }
 
     /** @return an ordered list of all dates between the start date and today (both inclusive) */
-    private fun getAllDates(startDate: LocalDate) =
-        CalendarUtil.getAllDates(startDate, LocalDate.now())
+    private fun getAllDates(startDate: LocalDate, today: LocalDate) =
+        CalendarUtil.getAllDates(startDate, today)
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/repository/CurrentDateRepository.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/repository/CurrentDateRepository.kt
@@ -1,28 +1,16 @@
 package com.lukeneedham.videodiary.data.repository
 
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
-import java.time.Duration
 import java.time.LocalDate
-import java.time.LocalDateTime
 
-class CurrentDateRepository(
-    private val ioDispatcher: CoroutineDispatcher,
-) {
+class CurrentDateRepository {
     val currentDate: Flow<LocalDate> = flow {
         while (true) {
-            val now = LocalDate.now()
-            emit(now)
-            val tomorrow = now.plusDays(1).atStartOfDay()
-            val delayMillis = Duration.between(
-                LocalDateTime.now(),
-                tomorrow
-            ).toMillis().coerceAtLeast(1000)
-            delay(delayMillis)
+            emit(LocalDate.now())
+            delay(60_000)
         }
-    }.distinctUntilChanged().flowOn(ioDispatcher)
+    }.distinctUntilChanged()
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/repository/CurrentDateRepository.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/repository/CurrentDateRepository.kt
@@ -1,0 +1,28 @@
+package com.lukeneedham.videodiary.data.repository
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class CurrentDateRepository(
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    val currentDate: Flow<LocalDate> = flow {
+        while (true) {
+            val now = LocalDate.now()
+            emit(now)
+            val tomorrow = now.plusDays(1).atStartOfDay()
+            val delayMillis = Duration.between(
+                LocalDateTime.now(),
+                tomorrow
+            ).toMillis().coerceAtLeast(1000)
+            delay(delayMillis)
+        }
+    }.distinctUntilChanged().flowOn(ioDispatcher)
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/data/repository/CurrentDateRepository.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/repository/CurrentDateRepository.kt
@@ -4,13 +4,21 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
+import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class CurrentDateRepository {
     val currentDate: Flow<LocalDate> = flow {
         while (true) {
-            emit(LocalDate.now())
-            delay(60_000)
+            val now = LocalDate.now()
+            emit(now)
+            val tomorrow = now.plusDays(1).atStartOfDay()
+            val delayMillis = Duration.between(
+                LocalDateTime.now(),
+                tomorrow
+            ).toMillis().coerceAtLeast(1000)
+            delay(delayMillis)
         }
     }.distinctUntilChanged()
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -88,9 +88,7 @@ object KoinModule {
 
     private fun getRepositories() = module {
         single {
-            CurrentDateRepository(
-                ioDispatcher = get(KoinQualifier.Dispatcher.io),
-            )
+            CurrentDateRepository()
         }
         single {
             CalendarRepository(

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -10,6 +10,7 @@ import com.lukeneedham.videodiary.data.persistence.VideoThumbnailExtractor
 import com.lukeneedham.videodiary.data.persistence.VideosDao
 import com.lukeneedham.videodiary.data.persistence.export.VideoExporter
 import com.lukeneedham.videodiary.data.repository.CalendarRepository
+import com.lukeneedham.videodiary.data.repository.CurrentDateRepository
 import com.lukeneedham.videodiary.data.repository.MockDataRepository
 import com.lukeneedham.videodiary.data.repository.VideoResolutionRepository
 import com.lukeneedham.videodiary.ui.feature.calendar.CalendarViewModel
@@ -87,9 +88,15 @@ object KoinModule {
 
     private fun getRepositories() = module {
         single {
+            CurrentDateRepository(
+                ioDispatcher = get(KoinQualifier.Dispatcher.io),
+            )
+        }
+        single {
             CalendarRepository(
                 videosDao = get(),
                 videoFileNameMapper = get(),
+                currentDateRepository = get(),
             )
         }
         factory {

--- a/buildSrc/src/main/kotlin/deps.kt
+++ b/buildSrc/src/main/kotlin/deps.kt
@@ -60,7 +60,7 @@ object deps {
         }
 
         object desugaring {
-            val coreLibrary = "com.android.tools:desugar_jdk_libs:2.0.2"
+            val coreLibrary = "com.android.tools:desugar_jdk_libs:2.1.4"
         }
 
         object coil {


### PR DESCRIPTION
## Summary

- **TODO item:** make the app reactive to the current date. if the current date changes while the app is active, the user wont be able to see the current day until they restart the app - fix this
- Adds `CurrentDateRepository` which provides a `Flow<LocalDate>` that calculates the delay until midnight and re-emits when the date changes
- `CalendarRepository.allDays` now combines `allVideos` with the current date flow, so the calendar automatically refreshes (adding the new day and updating `Day.isToday`) when midnight passes

## Test plan

- [ ] Open the app before midnight, leave it open, and verify the calendar updates to show the new day after midnight
- [ ] Verify the "Jump to Today" button correctly navigates to the new current day after midnight
- [ ] Verify normal calendar behavior is unaffected (scrolling, recording videos, viewing past days)
- [ ] Verify the date picker also reflects the updated day list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014T9oHjCZBzmrtz7drVNgV7

---
_Generated by [Claude Code](https://claude.ai/code/session_014T9oHjCZBzmrtz7drVNgV7)_