### PR TITLE
Add crash log page showing fatal crash logs

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/App.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/App.kt
@@ -1,10 +1,12 @@
 package com.lukeneedham.videodiary
 
 import android.app.Application
+import com.lukeneedham.videodiary.data.persistence.CrashLogDao
 import com.lukeneedham.videodiary.di.KoinModule
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import com.lukeneedham.videodiary.domain.util.logger.android.AndroidLoggerEngine
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.GlobalContext
 import org.koin.core.context.GlobalContext.startKoin
 
 class App : Application() {
@@ -17,6 +19,22 @@ class App : Application() {
         startKoin {
             modules(KoinModule.modules)
             androidContext(this@App)
+        }
+
+        installCrashLogHandler()
+    }
+
+    /** Persists fatal crashes to disk so they can be viewed later from the Debug page. */
+    private fun installCrashLogHandler() {
+        val crashLogDao = GlobalContext.get().get<CrashLogDao>()
+        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try {
+                crashLogDao.saveCrashLog(throwable)
+            } catch (e: Exception) {
+                Logger.error("Failed to save crash log", e)
+            }
+            defaultHandler?.uncaughtException(thread, throwable)
         }
     }
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/CrashLogDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/CrashLogDao.kt
@@ -1,0 +1,39 @@
+package com.lukeneedham.videodiary.data.persistence
+
+import android.content.Context
+import com.lukeneedham.videodiary.domain.model.CrashLog
+import com.lukeneedham.videodiary.domain.util.logger.Logger
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.time.Instant
+
+class CrashLogDao(
+    private val context: Context,
+) {
+    private val crashLogsDir = File(context.filesDir, "crashlogs").apply {
+        mkdirs()
+    }
+
+    /** Persists a fatal crash to disk. Called from the uncaught exception handler. */
+    fun saveCrashLog(throwable: Throwable) {
+        val timestamp = Instant.now()
+        val stackTrace = StringWriter().also { throwable.printStackTrace(PrintWriter(it)) }.toString()
+        File(crashLogsDir, "${timestamp.toEpochMilli()}.txt").writeText(stackTrace)
+    }
+
+    fun getAllCrashLogs(): List<CrashLog> {
+        val files = crashLogsDir.listFiles() ?: return emptyList()
+        return files.mapNotNull { file ->
+            val timestampMillis = file.nameWithoutExtension.toLongOrNull()
+            if (timestampMillis == null) {
+                Logger.warning("Skipping crash log with unrecognised file name: ${file.name}")
+                return@mapNotNull null
+            }
+            CrashLog(
+                timestamp = Instant.ofEpochMilli(timestampMillis),
+                stackTrace = file.readText(),
+            )
+        }.sortedByDescending { it.timestamp }
+    }
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.lukeneedham.videodiary.data.android.PermissionChecker
 import com.lukeneedham.videodiary.data.mapper.ThumbnailFileNameMapper
 import com.lukeneedham.videodiary.data.mapper.VideoFileNameMapper
+import com.lukeneedham.videodiary.data.persistence.CrashLogDao
 import com.lukeneedham.videodiary.data.persistence.SavedExportsDao
 import com.lukeneedham.videodiary.data.persistence.SettingsDao
 import com.lukeneedham.videodiary.data.persistence.VideoExportDao
@@ -17,6 +18,7 @@ import com.lukeneedham.videodiary.data.repository.MockDataRepository
 import com.lukeneedham.videodiary.data.repository.VideoResolutionRepository
 import com.lukeneedham.videodiary.ui.feature.calendar.CalendarViewModel
 import com.lukeneedham.videodiary.ui.feature.common.datepicker.DiaryDatePickerViewModel
+import com.lukeneedham.videodiary.ui.feature.crashlog.CrashLogViewModel
 import com.lukeneedham.videodiary.ui.feature.debug.DebugViewModel
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.ExportDiaryCreateViewModel
 import com.lukeneedham.videodiary.ui.feature.exportdiary.hub.ExportHubViewModel
@@ -91,6 +93,11 @@ object KoinModule {
             SavedExportsDao(
                 context = androidContext(),
                 roomDao = get<AppDatabase>().savedExportDao(),
+            )
+        }
+        single {
+            CrashLogDao(
+                context = androidContext(),
             )
         }
     }
@@ -196,6 +203,12 @@ object KoinModule {
                 mockDataRepository = get(),
                 settingsDao = get(),
                 videosDao = get(),
+                ioDispatcher = get(KoinQualifier.Dispatcher.io),
+            )
+        }
+        viewModel {
+            CrashLogViewModel(
+                crashLogDao = get(),
                 ioDispatcher = get(KoinQualifier.Dispatcher.io),
             )
         }

--- a/app/src/main/java/com/lukeneedham/videodiary/domain/model/CrashLog.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/domain/model/CrashLog.kt
@@ -1,0 +1,8 @@
+package com.lukeneedham.videodiary.domain.model
+
+import java.time.Instant
+
+data class CrashLog(
+    val timestamp: Instant,
+    val stackTrace: String,
+)

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/crashlog/CrashLogPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/crashlog/CrashLogPage.kt
@@ -1,0 +1,16 @@
+package com.lukeneedham.videodiary.ui.feature.crashlog
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun CrashLogPage(
+    viewModel: CrashLogViewModel,
+    canGoBack: Boolean,
+    onBack: () -> Unit,
+) {
+    CrashLogPageContent(
+        crashLogs = viewModel.crashLogs,
+        canGoBack = canGoBack,
+        onBack = onBack,
+    )
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/crashlog/CrashLogPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/crashlog/CrashLogPageContent.kt
@@ -1,0 +1,122 @@
+package com.lukeneedham.videodiary.ui.feature.crashlog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lukeneedham.videodiary.domain.model.CrashLog
+import com.lukeneedham.videodiary.ui.feature.common.toolbar.GenericToolbar
+import com.lukeneedham.videodiary.ui.theme.AppBackground
+import com.lukeneedham.videodiary.ui.theme.AppSurfaceVariant
+import com.lukeneedham.videodiary.ui.theme.Typography
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val timestampFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+@Composable
+fun CrashLogPageContent(
+    crashLogs: List<CrashLog>,
+    canGoBack: Boolean,
+    onBack: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(AppBackground)
+    ) {
+        GenericToolbar(
+            canGoBack = canGoBack,
+            onBack = onBack,
+        )
+
+        if (crashLogs.isEmpty()) {
+            Text(
+                text = "No crash logs recorded",
+                color = Color.White.copy(alpha = 0.4f),
+                fontSize = Typography.Size.extraSmall,
+                modifier = Modifier.padding(16.dp),
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                items(crashLogs, key = { it.timestamp.toEpochMilli() }) { crashLog ->
+                    CrashLogItem(crashLog)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CrashLogItem(crashLog: CrashLog) {
+    SelectionContainer {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(AppSurfaceVariant)
+                .padding(16.dp)
+        ) {
+            Text(
+                text = timestampFormatter.format(crashLog.timestamp.atZone(ZoneId.systemDefault())),
+                color = Color.White.copy(alpha = 0.6f),
+                fontSize = Typography.Size.extraSmall,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = crashLog.stackTrace,
+                color = Color.White,
+                fontSize = Typography.Size.extraSmall,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewEmpty() {
+    CrashLogPageContent(
+        crashLogs = emptyList(),
+        canGoBack = true,
+        onBack = {},
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewWithItems() {
+    CrashLogPageContent(
+        crashLogs = listOf(
+            CrashLog(
+                timestamp = Instant.now(),
+                stackTrace = "java.lang.RuntimeException: Something went wrong\n" +
+                    "\tat com.lukeneedham.videodiary.Foo.bar(Foo.kt:10)",
+            ),
+        ),
+        canGoBack = true,
+        onBack = {},
+    )
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/crashlog/CrashLogViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/crashlog/CrashLogViewModel.kt
@@ -1,0 +1,28 @@
+package com.lukeneedham.videodiary.ui.feature.crashlog
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lukeneedham.videodiary.data.persistence.CrashLogDao
+import com.lukeneedham.videodiary.domain.model.CrashLog
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class CrashLogViewModel(
+    private val crashLogDao: CrashLogDao,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+    var crashLogs: List<CrashLog> by mutableStateOf(emptyList())
+        private set
+
+    init {
+        viewModelScope.launch {
+            crashLogs = withContext(ioDispatcher) {
+                crashLogDao.getAllCrashLogs()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPage.kt
@@ -9,6 +9,7 @@ fun DebugPage(
     viewModel: DebugViewModel,
     canGoBack: Boolean,
     onBack: () -> Unit,
+    onCrashLogClick: () -> Unit,
 ) {
     val allowRetakeForPastDays by viewModel.allowRetakeForPastDays.collectAsState()
 
@@ -17,6 +18,7 @@ fun DebugPage(
         allowRetakeForPastDays = allowRetakeForPastDays,
         onAllowRetakeForPastDaysChange = viewModel::setAllowRetakeForPastDays,
         onResyncThumbnailsClick = viewModel::resyncThumbnails,
+        onCrashLogClick = onCrashLogClick,
         canGoBack = canGoBack,
         onBack = onBack,
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/debug/DebugPageContent.kt
@@ -26,6 +26,7 @@ fun DebugPageContent(
     allowRetakeForPastDays: Boolean,
     onAllowRetakeForPastDaysChange: (Boolean) -> Unit,
     onResyncThumbnailsClick: () -> Unit,
+    onCrashLogClick: () -> Unit,
     canGoBack: Boolean,
     onBack: () -> Unit,
 ) {
@@ -69,6 +70,12 @@ fun DebugPageContent(
                 description = "Deletes all generated thumbnails and recalculates them " +
                     "from the saved videos",
                 onClick = onResyncThumbnailsClick,
+            )
+
+            DebugOption(
+                title = "Crash logs",
+                description = "View all fatal crash logs recorded by the app",
+                onClick = onCrashLogClick,
             )
         }
     }
@@ -143,6 +150,7 @@ internal fun PreviewDebugPageContent() {
         allowRetakeForPastDays = false,
         onAllowRetakeForPastDaysChange = {},
         onResyncThumbnailsClick = {},
+        onCrashLogClick = {},
         canGoBack = true,
         onBack = {},
     )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalPage.kt
@@ -21,4 +21,5 @@ sealed class NormalPage : Parcelable {
     data class ExportDiaryView(val exportedVideo: ExportedVideo) : NormalPage()
 
     data object Debug : NormalPage()
+    data object CrashLog : NormalPage()
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalRouter.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalRouter.kt
@@ -5,6 +5,7 @@ import com.lukeneedham.videodiary.domain.model.ExportedVideo
 import com.lukeneedham.videodiary.domain.model.ShareRequest
 import com.lukeneedham.videodiary.domain.util.logger.Logger
 import com.lukeneedham.videodiary.ui.feature.calendar.CalendarPage
+import com.lukeneedham.videodiary.ui.feature.crashlog.CrashLogPage
 import com.lukeneedham.videodiary.ui.feature.debug.DebugPage
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.ExportDiaryCreatePage
 import com.lukeneedham.videodiary.ui.feature.exportdiary.hub.ExportHubPage
@@ -125,6 +126,15 @@ fun NormalRouter(
             )
 
             is NormalPage.Debug -> DebugPage(
+                viewModel = koinViewModel(),
+                canGoBack = canGoBack,
+                onBack = onBack,
+                onCrashLogClick = {
+                    navigate(NormalPage.CrashLog)
+                },
+            )
+
+            is NormalPage.CrashLog -> CrashLogPage(
                 viewModel = koinViewModel(),
                 canGoBack = canGoBack,
                 onBack = onBack,


### PR DESCRIPTION
## Summary
- Installs an uncaught exception handler in `App.kt` that persists fatal crash stack traces to disk (via a new `CrashLogDao`, files stored in `filesDir/crashlogs`), then delegates to the previous default handler so normal crash behaviour is unaffected.
- Adds a new **Crash Logs** page (`ui/feature/crashlog/`, following the existing Page/PageContent/ViewModel split) that lists all recorded fatal crash logs with selectable text (via `SelectionContainer`), so a crash's stack trace can be copied out for bug reports.
- Adds a "Crash logs" option to the Debug page that navigates to the new page (`NormalPage.CrashLog` / `NormalRouter`).
- Wires the new `CrashLogDao` and `CrashLogViewModel` into `di/KoinModule.kt`.

## Test plan
- [x] `./gradlew assembleDebug` builds successfully
- [x] `./gradlew test` passes
- [ ] Manually trigger a crash on a device/emulator, reopen the app, and confirm it appears on the Crash Logs page (opened from Debug) with selectable stack trace text

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013wETaZJ5uJ3Z1TmXSMAJSo)_