### PR TITLE
Use curved arrow share icon like WhatsApp

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,5 +4,4 @@ This is an ordered list of todo items. Each item should be done in isolation, an
 # Todos
 - on the create export page, once the user clicks to create the export, open a new page that shows progress and also a cancel button. when progress completes navigate automatically to the video view page
 - the export video view page needs to be updated to follow the same design as the calendar video player - video takes full width, height is driven by aspect ratio as from repo, video aligned to bottom, black toolbar aligned to top fills remaining height. toolbar contains back button, and name of export (if applicable) is centered, with the date range in small text underneath (or centered if there is no name). pause, mute buttons float aligned to bottom -left, share button floats aligned to bottom-right.
-- new share icon - use the curved arrow icon that whatsapp uses
 - improve onboarding flow - make beautiful, split across multiple pages, add page indicator at the bottom of each page so the user can see how far they are

--- a/app/src/main/res/drawable/share.xml
+++ b/app/src/main/res/drawable/share.xml
@@ -1,9 +1,20 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
+    android:viewportWidth="24"
+    android:viewportHeight="24">
   <path
-      android:fillColor="#FF000000"
-      android:pathData="M720,880q-50,0 -85,-35t-35,-85q0,-7 1,-14.5t3,-13.5L322,568q-17,15 -38,23.5t-44,8.5q-50,0 -85,-35t-35,-85q0,-50 35,-85t85,-35q23,0 44,8.5t38,23.5l282,-164q-2,-6 -3,-13.5t-1,-14.5q0,-50 35,-85t85,-35q50,0 85,35t35,85q0,50 -35,85t-85,35q-23,0 -44,-8.5T638,288L356,452q2,6 3,13.5t1,14.5q0,7 -1,14.5t-3,13.5l282,164q17,-15 38,-23.5t44,-8.5q50,0 85,35t35,85q0,50 -35,85t-85,35ZM720,240q17,0 28.5,-11.5T760,200q0,-17 -11.5,-28.5T720,160q-17,0 -28.5,11.5T680,200q0,17 11.5,28.5T720,240ZM240,520q17,0 28.5,-11.5T280,480q0,-17 -11.5,-28.5T240,440q-17,0 -28.5,11.5T200,480q0,17 11.5,28.5T240,520ZM720,800q17,0 28.5,-11.5T760,760q0,-17 -11.5,-28.5T720,720q-17,0 -28.5,11.5T680,760q0,17 11.5,28.5T720,800ZM720,200ZM240,480ZM720,760Z"/>
+      android:pathData="M4,20 L4,13 A4,4 0 0,1 8,9 L20,9"
+      android:strokeColor="#FF000000"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"/>
+  <path
+      android:pathData="M15,14 L20,9 L15,4"
+      android:strokeColor="#FF000000"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"/>
 </vector>


### PR DESCRIPTION
## Summary

Replaces the Material "network nodes" share icon (`app/src/main/res/drawable/share.xml`) with a curved forward-arrow icon (an elbow-shaped arrow with an arrowhead), matching the style WhatsApp uses for its share/forward action. This is the only place `R.drawable.share` is used as an icon (`CalendarDayBottomBar`'s share button), so the change is contained to the drawable resource.

Original TODO item (removed from `TODO.md`):
> new share icon - use the curved arrow icon that whatsapp uses

## Test plan
- [x] `./gradlew assembleDebug` builds successfully
- [ ] Manually verify the new share icon renders correctly on the Calendar day bottom bar

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01XAPBZszrvKoHvC7iMS8E3E

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAPBZszrvKoHvC7iMS8E3E)_