### PR TITLE
Add dedicated export progress page with cancel support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 This is an ordered list of todo items. Each item should be done in isolation, and a separate PR opened for each item. When an item is done, the PR should include the original TODO text in the description, and the todo should be removed from this list.
 
 # Todos
-- on the create export page, once the user clicks to create the export, open a new page that shows progress and also a cancel button. when progress completes navigate automatically to the video view page
 - the export video view page needs to be updated to follow the same design as the calendar video player - video takes full width, height is driven by aspect ratio as from repo, video aligned to bottom, black toolbar aligned to top fills remaining height. toolbar contains back button, and name of export (if applicable) is centered, with the date range in small text underneath (or centered if there is no name). pause, mute buttons float aligned to bottom -left, share button floats aligned to bottom-right.
 - new share icon - use the curved arrow icon that whatsapp uses
 - improve onboarding flow - make beautiful, split across multiple pages, add page indicator at the bottom of each page so the user can see how far they are

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoExportDao.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/VideoExportDao.kt
@@ -19,6 +19,8 @@ class VideoExportDao(
     fun export(videos: List<ExportDay>, exportIncludeDateStamp: Boolean): Flow<VideoExportState> =
         videoExporter.export(videos, outputFile, exportIncludeDateStamp)
 
+    fun cancel() = videoExporter.cancel()
+
     companion object {
         const val outputFileName = "export.mp4"
     }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/VideoExportState.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/VideoExportState.kt
@@ -6,4 +6,5 @@ sealed interface VideoExportState {
     data class InProgress(val progressFraction: Float) : VideoExportState
     data class Success(val outputFile: File) : VideoExportState
     data class Failure(val error: Exception) : VideoExportState
+    data object Cancelled : VideoExportState
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/VideoExporter.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/data/persistence/export/VideoExporter.kt
@@ -29,6 +29,7 @@ class VideoExporter(
 ) {
     private var isComplete = false
     private var failureException: Exception? = null
+    private var isCancelled = false
 
     private val listener = object : Transformer.Listener {
         override fun onCompleted(composition: Composition, exportResult: ExportResult) {
@@ -62,6 +63,7 @@ class VideoExporter(
 
         isComplete = false
         failureException = null
+        isCancelled = false
 
         val editedMediaItems = inputVideos.map { input ->
             val mediaItem = MediaItem.fromUri(input.video.toUri())
@@ -96,6 +98,12 @@ class VideoExporter(
             while (isFlowing) {
                 val error = failureException
                 val state = when {
+                    isCancelled -> {
+                        isFlowing = false
+                        outputFile.delete()
+                        VideoExportState.Cancelled
+                    }
+
                     isComplete -> {
                         isFlowing = false
                         VideoExportState.Success(outputFile)
@@ -116,6 +124,11 @@ class VideoExporter(
                 delay(250)
             }
         }
+    }
+
+    fun cancel() {
+        isCancelled = true
+        transformer.cancel()
     }
 
     private fun createTextOverlay(

--- a/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/di/KoinModule.kt
@@ -21,7 +21,9 @@ import com.lukeneedham.videodiary.ui.feature.common.datepicker.DiaryDatePickerVi
 import com.lukeneedham.videodiary.ui.feature.crashlog.CrashLogViewModel
 import com.lukeneedham.videodiary.ui.feature.debug.DebugViewModel
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.ExportDiaryCreateViewModel
+import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportRequest
 import com.lukeneedham.videodiary.ui.feature.exportdiary.hub.ExportHubViewModel
+import com.lukeneedham.videodiary.ui.feature.exportdiary.progress.ExportDiaryProgressViewModel
 import com.lukeneedham.videodiary.ui.feature.exportdiary.view.ExportDiaryViewViewModel
 import com.lukeneedham.videodiary.ui.feature.permissions.RequestPermissionsViewModel
 import com.lukeneedham.videodiary.ui.feature.record.check.CheckVideoViewModel
@@ -181,8 +183,13 @@ object KoinModule {
         }
         viewModel {
             ExportDiaryCreateViewModel(
-                videoExportDao = get(),
                 calendarRepository = get(),
+            )
+        }
+        viewModel { (exportRequest: ExportRequest) ->
+            ExportDiaryProgressViewModel(
+                exportRequest = exportRequest,
+                videoExportDao = get(),
                 savedExportsDao = get(),
                 ioDispatcher = get(KoinQualifier.Dispatcher.io),
             )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePage.kt
@@ -1,28 +1,19 @@
 package com.lukeneedham.videodiary.ui.feature.exportdiary.create
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import com.lukeneedham.videodiary.domain.model.ExportedVideo
+import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportRequest
 
 @Composable
 fun ExportDiaryCreatePage(
     viewModel: ExportDiaryCreateViewModel,
     canGoBack: Boolean,
     onBack: () -> Unit,
-    onExported: (exportedVideo: ExportedVideo) -> Unit,
+    onExportRequested: (exportRequest: ExportRequest) -> Unit,
 ) {
-    LaunchedEffect(viewModel) {
-        viewModel.onExportedFlow.collect {
-            onExported(it)
-        }
-    }
-
     ExportDiaryCreatePageContent(
         canGoBack = canGoBack,
         onBack = onBack,
         totalVideoCount = viewModel.totalVideoCount,
-        exportState = viewModel.exportState,
-        export = viewModel::export,
         exportStartDate = viewModel.exportStartDate,
         exportEndDate = viewModel.exportEndDate,
         selectedVideoCount = viewModel.selectedVideoCount,
@@ -34,5 +25,8 @@ fun ExportDiaryCreatePage(
         setExportIncludeDateStamp = { viewModel.exportIncludeDateStamp = it },
         exportName = viewModel.exportName,
         onExportNameChange = { viewModel.exportName = it },
+        export = {
+            viewModel.exportRequest?.let(onExportRequested)
+        },
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageContent.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.lukeneedham.videodiary.ui.feature.common.toolbar.GenericToolbar
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportDayThumbnail
-import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportState
 import java.time.LocalDate
 
 @Composable
@@ -26,7 +25,6 @@ fun ExportDiaryCreatePageContent(
     diaryStartDate: LocalDate?,
     exportStartDate: LocalDate?,
     exportEndDate: LocalDate?,
-    exportState: ExportState,
     onStartDateSelected: (LocalDate?) -> Unit,
     onEndDateSelected: (LocalDate?) -> Unit,
     exportIncludeDateStamp: Boolean,
@@ -59,7 +57,6 @@ fun ExportDiaryCreatePageContent(
                     selectedDayThumbnails = selectedDayThumbnails,
                     exportStartDate = exportStartDate,
                     exportEndDate = exportEndDate,
-                    exportState = exportState,
                     onStartDateSelected = onStartDateSelected,
                     onEndDateSelected = onEndDateSelected,
                     exportIncludeDateStamp = exportIncludeDateStamp,
@@ -85,7 +82,6 @@ internal fun PreviewExportDiaryPageContent() {
             totalVideoCount = 10,
             selectedVideoCount = 5,
             selectedDayThumbnails = emptyList(),
-            exportState = MockDataExportDiaryCreate.exportState,
             export = {},
             exportStartDate = MockDataExportDiaryCreate.startDate,
             exportEndDate = MockDataExportDiaryCreate.endDate,

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageReady.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreatePageReady.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxDefaults
-import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
@@ -41,7 +40,6 @@ import com.lukeneedham.videodiary.ui.feature.exportdiary.create.component.Export
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.component.ExportDiaryEmptyCreate
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.component.ExportDiaryThumbnailRow
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportDayThumbnail
-import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportState
 import com.lukeneedham.videodiary.ui.theme.Typography
 import java.time.LocalDate
 
@@ -52,7 +50,6 @@ fun ExportDiaryCreatePageReady(
     selectedDayThumbnails: List<ExportDayThumbnail>?,
     exportStartDate: LocalDate,
     exportEndDate: LocalDate,
-    exportState: ExportState,
     onStartDateSelected: (LocalDate?) -> Unit,
     onEndDateSelected: (LocalDate?) -> Unit,
     exportIncludeDateStamp: Boolean,
@@ -225,53 +222,16 @@ fun ExportDiaryCreatePageReady(
 
                     Spacer(modifier = Modifier.height(15.dp))
 
-                    when (exportState) {
-                        is ExportState.InProgress -> {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Text(
-                                    text = "Export in progress..."
-                                )
-                                Spacer(modifier = Modifier.height(10.dp))
-
-                                LinearProgressIndicator(
-                                    progress = exportState.progressFraction,
-                                    color = Color.Black,
-                                )
-                            }
-                        }
-
-                        is ExportState.Failed -> {
-                            Text(
-                                text = "Something went wrong during the export: ${exportState.error}"
-                            )
-                            Spacer(modifier = Modifier.height(5.dp))
-                            Text(
-                                text = "Feel free to try again"
-                            )
-                            Spacer(modifier = Modifier.height(5.dp))
-                            Button(
-                                text = "Export",
-                                onClick = export,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-
-                        ExportState.Ready -> {
-                            if (selectedVideoCount == 0) {
-                                Text(
-                                    text = "Cannot export - please select at least one video",
-                                )
-                            } else {
-                                Button(
-                                    text = "Export",
-                                    onClick = export,
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                            }
-                        }
+                    if (selectedVideoCount == 0) {
+                        Text(
+                            text = "Cannot export - please select at least one video",
+                        )
+                    } else {
+                        Button(
+                            text = "Export",
+                            onClick = export,
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
                 }
             }
@@ -306,7 +266,6 @@ internal fun PreviewExportDiaryCreatePageReady() {
         selectedDayThumbnails = emptyList(),
         exportStartDate = MockDataExportDiaryCreate.startDate,
         exportEndDate = MockDataExportDiaryCreate.endDate,
-        exportState = MockDataExportDiaryCreate.exportState,
         onStartDateSelected = {},
         onEndDateSelected = {},
         exportIncludeDateStamp = true,

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreateViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/ExportDiaryCreateViewModel.kt
@@ -6,37 +6,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.lukeneedham.videodiary.data.persistence.SavedExportsDao
-import com.lukeneedham.videodiary.data.persistence.VideoExportDao
-import com.lukeneedham.videodiary.data.persistence.export.VideoExportState
 import com.lukeneedham.videodiary.data.repository.CalendarRepository
 import com.lukeneedham.videodiary.domain.model.Day
-import com.lukeneedham.videodiary.domain.model.ExportedVideo
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportDay
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportDayThumbnail
-import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportState
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportRequest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
 class ExportDiaryCreateViewModel(
-    private val videoExportDao: VideoExportDao,
     private val calendarRepository: CalendarRepository,
-    private val savedExportsDao: SavedExportsDao,
-    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
     private var allDays: List<Day> by mutableStateOf(emptyList())
 
     val totalVideoCount: Int? by derivedStateOf {
         allDays.count { it.videoFile != null }
     }
-
-    var exportState: ExportState by mutableStateOf(ExportState.Ready)
-        private set
 
     var exportStartDate: LocalDate? by mutableStateOf(null)
     var exportEndDate: LocalDate? by mutableStateOf(null)
@@ -88,11 +73,18 @@ class ExportDiaryCreateViewModel(
         allDays.firstOrNull()?.date
     }
 
-    private val onExportedMutable = MutableSharedFlow<ExportedVideo>(
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-        extraBufferCapacity = 1,
-    )
-    val onExportedFlow = onExportedMutable.asSharedFlow()
+    val exportRequest: ExportRequest? by derivedStateOf {
+        val days = selectedDays ?: return@derivedStateOf null
+        val startDate = exportStartDate ?: return@derivedStateOf null
+        val endDate = exportEndDate ?: return@derivedStateOf null
+        ExportRequest(
+            days = days,
+            startDate = startDate,
+            endDate = endDate,
+            includeDateStamp = exportIncludeDateStamp,
+            name = exportName.trim(),
+        )
+    }
 
     init {
         viewModelScope.launch {
@@ -103,64 +95,6 @@ class ExportDiaryCreateViewModel(
                 }
                 if (exportEndDate == null) {
                     exportEndDate = days.lastOrNull()?.date
-                }
-            }
-        }
-    }
-
-    fun export() {
-        val selectedDays = selectedDays
-        if (selectedDays == null) {
-            exportState = ExportState.Failed("Selected videos could not be computed")
-            return
-        }
-        val endDate = exportEndDate
-        if (endDate == null) {
-            exportState = ExportState.Failed("End date is not set")
-            return
-        }
-        val startDate = exportStartDate
-        if (startDate == null) {
-            exportState = ExportState.Failed("Start date is not set")
-            return
-        }
-
-        viewModelScope.launch {
-            videoExportDao.export(selectedDays, exportIncludeDateStamp).collect { state ->
-                when (state) {
-                    is VideoExportState.Failure -> {
-                        val error = state.error
-                        val errorMessage = error.message ?: error.toString()
-                        exportState = ExportState.Failed(errorMessage)
-                    }
-
-                    is VideoExportState.InProgress -> {
-                        exportState = ExportState.InProgress(state.progressFraction)
-                    }
-
-                    is VideoExportState.Success -> {
-                        val exportedVideo = ExportedVideo(
-                            videoFile = state.outputFile,
-                            startDate = startDate,
-                            endDate = endDate,
-                            dayVideoCount = selectedDays.size,
-                        )
-
-                        val trimmedName = exportName.trim()
-                        if (trimmedName.isNotEmpty()) {
-                            val dates = selectedDays?.map { it.date } ?: emptyList()
-                            withContext(ioDispatcher) {
-                                savedExportsDao.saveExport(
-                                    trimmedName,
-                                    exportedVideo,
-                                    dates,
-                                )
-                            }
-                        }
-
-                        exportState = ExportState.Ready
-                        onExportedMutable.emit(exportedVideo)
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/MockDataExportDiaryCreate.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/MockDataExportDiaryCreate.kt
@@ -1,10 +1,8 @@
 package com.lukeneedham.videodiary.ui.feature.exportdiary.create
 
-import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportState
 import java.time.LocalDate
 
 object MockDataExportDiaryCreate {
-    val exportState = ExportState.Ready
     val diaryStartDate = LocalDate.of(2024, 3, 25)
     val startDate = LocalDate.of(2024, 3, 27)
     val endDate = LocalDate.of(2024, 4, 20)

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/model/ExportDay.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/model/ExportDay.kt
@@ -1,10 +1,12 @@
 package com.lukeneedham.videodiary.ui.feature.exportdiary.create.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.io.File
 import java.time.LocalDate
-import java.time.LocalTime
 
+@Parcelize
 data class ExportDay(
     val date: LocalDate,
     val video: File,
-)
+) : Parcelable

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/model/ExportRequest.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/model/ExportRequest.kt
@@ -1,0 +1,14 @@
+package com.lukeneedham.videodiary.ui.feature.exportdiary.create.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.time.LocalDate
+
+@Parcelize
+data class ExportRequest(
+    val days: List<ExportDay>,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val includeDateStamp: Boolean,
+    val name: String,
+) : Parcelable

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/model/ExportState.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/create/model/ExportState.kt
@@ -1,7 +1,0 @@
-package com.lukeneedham.videodiary.ui.feature.exportdiary.create.model
-
-sealed interface ExportState {
-    object Ready : ExportState
-    data class Failed(val error: String) : ExportState
-    data class InProgress(val progressFraction: Float) : ExportState
-}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/ExportDiaryProgressPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/ExportDiaryProgressPage.kt
@@ -1,0 +1,30 @@
+package com.lukeneedham.videodiary.ui.feature.exportdiary.progress
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.lukeneedham.videodiary.domain.model.ExportedVideo
+
+@Composable
+fun ExportDiaryProgressPage(
+    viewModel: ExportDiaryProgressViewModel,
+    onExported: (exportedVideo: ExportedVideo) -> Unit,
+    onExit: () -> Unit,
+) {
+    LaunchedEffect(viewModel) {
+        viewModel.onExportedFlow.collect {
+            onExported(it)
+        }
+    }
+    LaunchedEffect(viewModel) {
+        viewModel.onExitFlow.collect {
+            onExit()
+        }
+    }
+
+    ExportDiaryProgressPageContent(
+        progressState = viewModel.progressState,
+        isCancelling = viewModel.isCancelling,
+        onCancelClick = viewModel::cancel,
+        onBackClick = viewModel::dismissFailure,
+    )
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/ExportDiaryProgressPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/ExportDiaryProgressPageContent.kt
@@ -1,0 +1,110 @@
+package com.lukeneedham.videodiary.ui.feature.exportdiary.progress
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lukeneedham.videodiary.ui.feature.common.Button
+import com.lukeneedham.videodiary.ui.feature.exportdiary.progress.model.ExportProgressState
+import com.lukeneedham.videodiary.ui.theme.Typography
+
+@Composable
+fun ExportDiaryProgressPageContent(
+    progressState: ExportProgressState,
+    isCancelling: Boolean,
+    onCancelClick: () -> Unit,
+    onBackClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .padding(32.dp)
+        ) {
+            when (progressState) {
+                is ExportProgressState.InProgress -> {
+                    Text(
+                        text = "Exporting your diary...",
+                        color = Color.Black,
+                        fontSize = Typography.Size.medium,
+                        textAlign = TextAlign.Center,
+                    )
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    LinearProgressIndicator(
+                        progress = progressState.progressFraction,
+                        color = Color.Black,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+
+                    Spacer(modifier = Modifier.height(30.dp))
+
+                    Button(
+                        text = if (isCancelling) "Cancelling..." else "Cancel",
+                        onClick = onCancelClick,
+                        enabled = !isCancelling,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                is ExportProgressState.Failed -> {
+                    Text(
+                        text = "Something went wrong during the export: ${progressState.error}",
+                        color = Color.Black,
+                        textAlign = TextAlign.Center,
+                    )
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Button(
+                        text = "Back",
+                        onClick = onBackClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun PreviewExportDiaryProgressPageContentInProgress() {
+    ExportDiaryProgressPageContent(
+        progressState = MockDataExportDiaryProgress.inProgress,
+        isCancelling = false,
+        onCancelClick = {},
+        onBackClick = {},
+    )
+}
+
+@Preview
+@Composable
+internal fun PreviewExportDiaryProgressPageContentFailed() {
+    ExportDiaryProgressPageContent(
+        progressState = MockDataExportDiaryProgress.failed,
+        isCancelling = false,
+        onCancelClick = {},
+        onBackClick = {},
+    )
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/ExportDiaryProgressViewModel.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/ExportDiaryProgressViewModel.kt
@@ -1,0 +1,105 @@
+package com.lukeneedham.videodiary.ui.feature.exportdiary.progress
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lukeneedham.videodiary.data.persistence.SavedExportsDao
+import com.lukeneedham.videodiary.data.persistence.VideoExportDao
+import com.lukeneedham.videodiary.data.persistence.export.VideoExportState
+import com.lukeneedham.videodiary.domain.model.ExportedVideo
+import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportRequest
+import com.lukeneedham.videodiary.ui.feature.exportdiary.progress.model.ExportProgressState
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ExportDiaryProgressViewModel(
+    private val exportRequest: ExportRequest,
+    private val videoExportDao: VideoExportDao,
+    private val savedExportsDao: SavedExportsDao,
+    private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    var progressState: ExportProgressState by mutableStateOf(ExportProgressState.InProgress(0f))
+        private set
+
+    var isCancelling: Boolean by mutableStateOf(false)
+        private set
+
+    private val onExportedMutable = MutableSharedFlow<ExportedVideo>(
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        extraBufferCapacity = 1,
+    )
+    val onExportedFlow = onExportedMutable.asSharedFlow()
+
+    private val onExitMutable = MutableSharedFlow<Unit>(
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        extraBufferCapacity = 1,
+    )
+    val onExitFlow = onExitMutable.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            videoExportDao.export(exportRequest.days, exportRequest.includeDateStamp).collect { state ->
+                when (state) {
+                    is VideoExportState.Failure -> {
+                        val error = state.error
+                        progressState = ExportProgressState.Failed(error.message ?: error.toString())
+                    }
+
+                    is VideoExportState.InProgress -> {
+                        progressState = ExportProgressState.InProgress(state.progressFraction)
+                    }
+
+                    is VideoExportState.Success -> {
+                        val exportedVideo = ExportedVideo(
+                            videoFile = state.outputFile,
+                            startDate = exportRequest.startDate,
+                            endDate = exportRequest.endDate,
+                            dayVideoCount = exportRequest.days.size,
+                        )
+
+                        val name = exportRequest.name
+                        if (name.isNotEmpty()) {
+                            withContext(ioDispatcher) {
+                                savedExportsDao.saveExport(
+                                    name,
+                                    exportedVideo,
+                                    exportRequest.days.map { it.date },
+                                )
+                            }
+                        }
+
+                        onExportedMutable.emit(exportedVideo)
+                    }
+
+                    VideoExportState.Cancelled -> {
+                        onExitMutable.emit(Unit)
+                    }
+                }
+            }
+        }
+    }
+
+    fun cancel() {
+        if (isCancelling) return
+        isCancelling = true
+        videoExportDao.cancel()
+    }
+
+    fun dismissFailure() {
+        viewModelScope.launch {
+            onExitMutable.emit(Unit)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        videoExportDao.cancel()
+    }
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/MockDataExportDiaryProgress.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/MockDataExportDiaryProgress.kt
@@ -1,0 +1,8 @@
+package com.lukeneedham.videodiary.ui.feature.exportdiary.progress
+
+import com.lukeneedham.videodiary.ui.feature.exportdiary.progress.model.ExportProgressState
+
+object MockDataExportDiaryProgress {
+    val inProgress = ExportProgressState.InProgress(0.4f)
+    val failed = ExportProgressState.Failed("Something broke")
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/model/ExportProgressState.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/progress/model/ExportProgressState.kt
@@ -1,0 +1,6 @@
+package com.lukeneedham.videodiary.ui.feature.exportdiary.progress.model
+
+sealed interface ExportProgressState {
+    data class InProgress(val progressFraction: Float) : ExportProgressState
+    data class Failed(val error: String) : ExportProgressState
+}

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalPage.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalPage.kt
@@ -3,8 +3,8 @@ package com.lukeneedham.videodiary.ui.navigation.normal
 import android.net.Uri
 import android.os.Parcelable
 import com.lukeneedham.videodiary.domain.model.ExportedVideo
+import com.lukeneedham.videodiary.ui.feature.exportdiary.create.model.ExportRequest
 import kotlinx.parcelize.Parcelize
-import java.io.File
 import java.time.LocalDate
 
 @Parcelize
@@ -18,6 +18,7 @@ sealed class NormalPage : Parcelable {
 
     data object ExportHub : NormalPage()
     data object ExportDiaryCreate : NormalPage()
+    data class ExportDiaryProgress(val exportRequest: ExportRequest) : NormalPage()
     data class ExportDiaryView(val exportedVideo: ExportedVideo) : NormalPage()
 
     data object Debug : NormalPage()

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalRouter.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/navigation/normal/NormalRouter.kt
@@ -9,6 +9,7 @@ import com.lukeneedham.videodiary.ui.feature.crashlog.CrashLogPage
 import com.lukeneedham.videodiary.ui.feature.debug.DebugPage
 import com.lukeneedham.videodiary.ui.feature.exportdiary.create.ExportDiaryCreatePage
 import com.lukeneedham.videodiary.ui.feature.exportdiary.hub.ExportHubPage
+import com.lukeneedham.videodiary.ui.feature.exportdiary.progress.ExportDiaryProgressPage
 import com.lukeneedham.videodiary.ui.feature.exportdiary.view.ExportDiaryViewPage
 import com.lukeneedham.videodiary.ui.feature.record.check.CheckVideoPage
 import com.lukeneedham.videodiary.ui.feature.record.film.RecordVideoPage
@@ -112,9 +113,22 @@ fun NormalRouter(
                 viewModel = koinViewModel(),
                 canGoBack = canGoBack,
                 onBack = onBack,
-                onExported = {
-                    navigate(NormalPage.ExportDiaryView(it))
+                onExportRequested = { exportRequest ->
+                    navigate(NormalPage.ExportDiaryProgress(exportRequest))
                 }
+            )
+
+            is NormalPage.ExportDiaryProgress -> ExportDiaryProgressPage(
+                viewModel = koinViewModel {
+                    parametersOf(page.exportRequest)
+                },
+                onExported = { exportedVideo ->
+                    navController.popUpTo { it is NormalPage.ExportDiaryCreate }
+                    navigate(NormalPage.ExportDiaryView(exportedVideo))
+                },
+                onExit = {
+                    pop()
+                },
             )
 
             is NormalPage.ExportDiaryView -> ExportDiaryViewPage(


### PR DESCRIPTION
## Summary

Implements the top item from `TODO.md`:

> on the create export page, once the user clicks to create the export, open a new page that shows progress and also a cancel button. when progress completes navigate automatically to the video view page

- Clicking **Export** on the create-export page now navigates to a new dedicated progress page instead of showing progress inline on the create page.
- The new page shows a progress bar and a **Cancel** button. Cancelling stops the underlying Media3 `Transformer` and deletes the partial output file, then returns to the create page.
- On success, the app automatically navigates to the exported video view page (replacing the progress page in the back stack, so back navigation returns to the create page, matching prior behaviour).
- The export parameters (selected videos, date range, include-date-stamp, name) are now passed between pages via a new `ExportRequest` model.
- `ExportDiaryCreateViewModel` no longer performs the export itself — that responsibility moved to the new `ExportDiaryProgressViewModel`, which owns the export/cancel/save-export flow.

## Test plan

- [x] `./gradlew assembleDebug` builds successfully
- [x] `./gradlew test` passes
- [ ] Manually verify: create export → progress page shows → cancel returns to create page with a clean partial-file removal
- [ ] Manually verify: create export → progress page shows → completes → auto-navigates to video view page
- [ ] Manually verify: back button from video view page returns to create page (not progress page)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUsgkhSfoS4dTzkASz63ZV)_