### PR TITLE
Swap VideoToolbarLayout: black bar to bottom, glassy controls to top

### DIFF
--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarDaySelector.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarDaySelector.kt
@@ -1,26 +1,20 @@
 package com.lukeneedham.videodiary.ui.feature.calendar.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Text
-import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.R
+import com.lukeneedham.videodiary.ui.feature.common.glass.GlassIconButton
 
 @Composable
 fun CalendarDaySelector(
@@ -34,36 +28,11 @@ fun CalendarDaySelector(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
     ) {
-        @Composable
-        fun Button(
-            iconRes: Int,
-            contentDescription: String,
-            onClick: () -> Unit,
-        ) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .clip(CircleShape)
-                    .size(50.dp)
-                    .clickable {
-                        onClick()
-                    }
-            ) {
-                Image(
-                    painter = painterResource(iconRes),
-                    contentDescription = contentDescription,
-                    colorFilter = ColorFilter.tint(color = Color.White),
-                    modifier = Modifier.size(24.dp)
-                )
-            }
-        }
-
-        Button(
+        GlassIconButton(
             iconRes = R.drawable.chevron_left,
             contentDescription = "Previous",
-        ) {
-            onPrevious()
-        }
+            onClick = onPrevious,
+        )
 
         Box(
             contentAlignment = Alignment.Center,
@@ -80,12 +49,11 @@ fun CalendarDaySelector(
             )
         }
 
-        Button(
+        GlassIconButton(
             iconRes = R.drawable.chevron_right,
             contentDescription = "Next",
-        ) {
-            onNext()
-        }
+            onClick = onNext,
+        )
     }
 }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarScroller.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarScroller.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -25,6 +26,7 @@ import com.lukeneedham.videodiary.domain.model.ShareRequest
 import com.lukeneedham.videodiary.domain.util.date.StandardDateTimeFormatter
 import com.lukeneedham.videodiary.ui.feature.calendar.MockDataCalendar
 import com.lukeneedham.videodiary.ui.feature.calendar.component.day.CalendarDayContent
+import com.lukeneedham.videodiary.ui.feature.calendar.component.day.bottombar.CalendarDayBottomBar
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoToolbarLayout
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.rememberVideoPlayerController
@@ -119,7 +121,7 @@ fun CalendarScroller(
 
     VideoToolbarLayout(
         videoAspectRatio = videoAspectRatio,
-        toolbar = {
+        topOverlay = {
             CalendarTopBar(
                 currentDateFormatted = currentDateFormatted,
                 onPrevious = onPrevious,
@@ -128,6 +130,17 @@ fun CalendarScroller(
                 goToToday = goToToday,
                 onMenuClick = onMenuClick,
                 isToday = currentDay.isToday,
+            )
+        },
+        bottomBar = {
+            CalendarDayBottomBar(
+                videoPlayerController = videoPlayerController,
+                day = currentDay,
+                isEditable = currentDay.isToday || allowEditPastDays,
+                onRecordVideoClick = { onRecordVideoClick(currentDay.date) },
+                onDeleteVideoClick = { onDeleteVideoClick(currentDay.date) },
+                share = share,
+                modifier = Modifier.align(Alignment.Center),
             )
         },
     ) { aspectRatio ->
@@ -162,11 +175,7 @@ fun CalendarScroller(
                     onRecordVideoClick = {
                         onRecordVideoClick(date)
                     },
-                    onDeleteVideoClick = {
-                        onDeleteVideoClick(date)
-                    },
                     videoPlayerController = videoPlayerController,
-                    share = share,
                 )
             }
         }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarTopBar.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/CalendarTopBar.kt
@@ -1,28 +1,20 @@
 package com.lukeneedham.videodiary.ui.feature.calendar.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.R
+import com.lukeneedham.videodiary.ui.feature.common.glass.GlassIconButton
 
 @Composable
 fun CalendarTopBar(
@@ -35,68 +27,37 @@ fun CalendarTopBar(
     isToday: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier.fillMaxSize()
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp)
+        GlassIconButton(
+            iconRes = R.drawable.menu,
+            contentDescription = "Menu",
+            onClick = onMenuClick,
+        )
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.weight(1f)
         ) {
-            TopBarIconButton(
-                iconRes = R.drawable.menu,
-                contentDescription = "Menu",
-                modifier = Modifier.clickable {
-                    onMenuClick()
-                }
-            )
-
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.weight(1f)
-            ) {
-                CalendarDaySelector(
-                    currentDate = currentDateFormatted,
-                    onPrevious = onPrevious,
-                    onNext = onNext,
-                    openDayPicker = openDayPicker,
-                )
-            }
-
-            val todayAlpha = if (isToday) 0f else 1f
-            TopBarIconButton(
-                iconRes = R.drawable.calendar_today,
-                contentDescription = "Jump to today",
-                modifier = Modifier
-                    .alpha(todayAlpha)
-                    .clickable(
-                        enabled = !isToday
-                    ) {
-                        goToToday()
-                    }
+            CalendarDaySelector(
+                currentDate = currentDateFormatted,
+                onPrevious = onPrevious,
+                onNext = onNext,
+                openDayPicker = openDayPicker,
             )
         }
-    }
-}
 
-@Composable
-private fun TopBarIconButton(
-    iconRes: Int,
-    contentDescription: String?,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier
-            .minimumInteractiveComponentSize()
-            .clip(CircleShape)
-    ) {
-        Image(
-            painter = painterResource(iconRes),
-            contentDescription = contentDescription,
-            colorFilter = ColorFilter.tint(Color.White),
-            modifier = Modifier.size(24.dp),
+        val todayAlpha = if (isToday) 0f else 1f
+        GlassIconButton(
+            iconRes = R.drawable.calendar_today,
+            contentDescription = "Jump to today",
+            onClick = goToToday,
+            enabled = !isToday,
+            modifier = Modifier.alpha(todayAlpha),
         )
     }
 }
@@ -108,7 +69,7 @@ internal fun PreviewCalendarTopBar() {
         modifier = Modifier
             .fillMaxWidth()
             .height(100.dp)
-            .background(Color.Black)
+            .background(Color.DarkGray)
     ) {
         CalendarTopBar(
             currentDateFormatted = "30 Nov",
@@ -129,7 +90,7 @@ internal fun PreviewCalendarTopBarToday() {
         modifier = Modifier
             .fillMaxWidth()
             .height(100.dp)
-            .background(Color.Black)
+            .background(Color.DarkGray)
     ) {
         CalendarTopBar(
             currentDateFormatted = "30 Nov",

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/CalendarDayContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/calendar/component/day/CalendarDayContent.kt
@@ -1,19 +1,12 @@
 package com.lukeneedham.videodiary.ui.feature.calendar.component.day
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.domain.model.Day
-import com.lukeneedham.videodiary.domain.model.ShareRequest
 import com.lukeneedham.videodiary.ui.feature.calendar.MockDataCalendar
-import com.lukeneedham.videodiary.ui.feature.calendar.component.day.bottombar.CalendarDayBottomBar
 import com.lukeneedham.videodiary.ui.feature.calendar.component.day.card.CalendarDayCard
-import com.lukeneedham.videodiary.ui.feature.common.glass.BottomScrim
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.rememberVideoPlayerController
 
@@ -24,40 +17,16 @@ fun CalendarDayContent(
     videoPlayerController: VideoPlayerController,
     allowEditPastDays: Boolean,
     onRecordVideoClick: () -> Unit,
-    onDeleteVideoClick: () -> Unit,
-    share: (ShareRequest) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val isEditable = day.isToday || allowEditPastDays
-
-    Box(
-        modifier = modifier.fillMaxSize()
-    ) {
-        CalendarDayCard(
-            day = day,
-            videoAspectRatio = videoAspectRatio,
-            allowRetakeForPastDays = allowEditPastDays,
-            onRecordVideoClick = onRecordVideoClick,
-            videoPlayerController = videoPlayerController,
-            modifier = Modifier.fillMaxSize(),
-        )
-
-        BottomScrim(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .height(190.dp)
-        )
-
-        CalendarDayBottomBar(
-            videoPlayerController = videoPlayerController,
-            day = day,
-            isEditable = isEditable,
-            onRecordVideoClick = onRecordVideoClick,
-            onDeleteVideoClick = onDeleteVideoClick,
-            share = share,
-            modifier = Modifier.align(Alignment.BottomCenter)
-        )
-    }
+    CalendarDayCard(
+        day = day,
+        videoAspectRatio = videoAspectRatio,
+        allowRetakeForPastDays = allowEditPastDays,
+        onRecordVideoClick = onRecordVideoClick,
+        videoPlayerController = videoPlayerController,
+        modifier = modifier.fillMaxSize(),
+    )
 }
 
 @Preview
@@ -69,7 +38,5 @@ internal fun PreviewCalendarDayContent() {
         onRecordVideoClick = {},
         videoAspectRatio = 1f,
         videoPlayerController = rememberVideoPlayerController(),
-        onDeleteVideoClick = {},
-        share = {},
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/glass/GlassComponents.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/glass/GlassComponents.kt
@@ -200,8 +200,8 @@ fun BottomScrim(modifier: Modifier = Modifier) {
 }
 
 /**
- * A full-width row of floating "glass" controls (e.g. mute/play/share buttons), intended to
- * overlap the bottom of a video.
+ * A full-width row of "glass" controls (e.g. mute/play/share buttons), intended for a video's
+ * bottom toolbar.
  */
 @Composable
 fun VideoControlsRow(
@@ -213,8 +213,7 @@ fun VideoControlsRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp)
-            .padding(bottom = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp),
         content = content,
     )
 }

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoToolbarLayout.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/common/videoplayer/VideoToolbarLayout.kt
@@ -7,44 +7,69 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lukeneedham.videodiary.ui.feature.common.glass.GlassIconButton
+import com.lukeneedham.videodiary.ui.feature.common.glass.TopScrim
+import com.lukeneedham.videodiary.R
 
 /**
- * Layout shared by full-screen video viewers (calendar day, export view): a black toolbar
- * filling the space above the video, and the video itself below - full width, with its height
- * driven by [videoAspectRatio]. The video box (and [video] slot) is omitted while
- * [videoAspectRatio] is unknown.
+ * Layout shared by full-screen video viewers (calendar day, export view): the video fills the
+ * space at the top - full width, with its height driven by [videoAspectRatio] - with [topOverlay]
+ * floating "glass" controls over its top edge, and a black toolbar below holding [bottomBar]. The
+ * video box (and [video]/[topOverlay] slots) is omitted while [videoAspectRatio] is unknown.
  */
 @Composable
 fun VideoToolbarLayout(
     videoAspectRatio: Float?,
     modifier: Modifier = Modifier,
-    toolbar: @Composable BoxScope.() -> Unit,
+    topOverlay: @Composable BoxScope.() -> Unit,
+    bottomBar: @Composable BoxScope.() -> Unit,
     video: @Composable BoxScope.(aspectRatio: Float) -> Unit,
 ) {
     Column(modifier = modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            if (videoAspectRatio != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(videoAspectRatio),
+                ) {
+                    video(videoAspectRatio)
+                }
+
+                TopScrim(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .height(140.dp),
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .statusBarsPadding(),
+                content = topOverlay,
+            )
+        }
+
         Box(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
-                .background(Color.Black),
-            content = toolbar,
+                .background(Color.Black)
+                .navigationBarsPadding(),
+            content = bottomBar,
         )
-
-        if (videoAspectRatio != null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(videoAspectRatio),
-            ) {
-                video(videoAspectRatio)
-            }
-        }
     }
 }
 
@@ -53,9 +78,17 @@ fun VideoToolbarLayout(
 private fun PreviewVideoToolbarLayout() {
     VideoToolbarLayout(
         videoAspectRatio = 1f,
-        toolbar = {
+        topOverlay = {
+            GlassIconButton(
+                iconRes = R.drawable.close,
+                contentDescription = "Close",
+                onClick = {},
+                modifier = Modifier.align(Alignment.TopStart),
+            )
+        },
+        bottomBar = {
             Text(
-                text = "Toolbar",
+                text = "Bottom bar",
                 color = Color.White,
                 modifier = Modifier.align(Alignment.Center),
             )

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/view/ExportDiaryViewPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/exportdiary/view/ExportDiaryViewPageContent.kt
@@ -1,7 +1,5 @@
 package com.lukeneedham.videodiary.ui.feature.exportdiary.view
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,17 +10,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Text
-import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,12 +50,49 @@ fun ExportDiaryViewPageContent(
 
     VideoToolbarLayout(
         videoAspectRatio = videoAspectRatio,
-        toolbar = {
+        topOverlay = {
             ExportDiaryViewToolbar(
                 exportedVideo = exportedVideo,
                 canGoBack = canGoBack,
                 onBack = onBack,
             )
+        },
+        bottomBar = {
+            VideoControlsRow(
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                val muteIcon =
+                    if (controller.isVolumeOn) R.drawable.volume_on else R.drawable.volume_off
+                GlassIconButton(
+                    iconRes = muteIcon,
+                    contentDescription = "Toggle sound",
+                    onClick = { controller.toggleVolumeOn() },
+                )
+
+                val isPlaying = !controller.isTogglePaused
+                val playIcon = if (isPlaying) R.drawable.pause else R.drawable.play
+                GlassIconButton(
+                    iconRes = playIcon,
+                    contentDescription = "Play/pause",
+                    onClick = { controller.toggleIsPlaying() },
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                GlassIconButton(
+                    iconRes = R.drawable.share,
+                    contentDescription = "Share",
+                    onClick = {
+                        val shareText = "Full Video Diary"
+                        val request = ShareRequest(
+                            title = shareText,
+                            text = shareText,
+                            video = videoFile,
+                        )
+                        share(request)
+                    },
+                )
+            }
         },
     ) { aspectRatio ->
         VideoPlayer(
@@ -71,42 +101,6 @@ fun ExportDiaryViewPageContent(
             controller = controller,
             modifier = Modifier.fillMaxSize(),
         )
-
-        VideoControlsRow(
-            modifier = Modifier.align(Alignment.BottomCenter)
-        ) {
-            val muteIcon =
-                if (controller.isVolumeOn) R.drawable.volume_on else R.drawable.volume_off
-            GlassIconButton(
-                iconRes = muteIcon,
-                contentDescription = "Toggle sound",
-                onClick = { controller.toggleVolumeOn() },
-            )
-
-            val isPlaying = !controller.isTogglePaused
-            val playIcon = if (isPlaying) R.drawable.pause else R.drawable.play
-            GlassIconButton(
-                iconRes = playIcon,
-                contentDescription = "Play/pause",
-                onClick = { controller.toggleIsPlaying() },
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            GlassIconButton(
-                iconRes = R.drawable.share,
-                contentDescription = "Share",
-                onClick = {
-                    val shareText = "Full Video Diary"
-                    val request = ShareRequest(
-                        title = shareText,
-                        text = shareText,
-                        video = videoFile,
-                    )
-                    share(request)
-                },
-            )
-        }
     }
 }
 
@@ -117,83 +111,55 @@ private fun ExportDiaryViewToolbar(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = modifier.fillMaxSize()
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp)
-        ) {
-            Box(modifier = Modifier.size(50.dp)) {
-                if (canGoBack) {
-                    ToolbarIconButton(
-                        iconRes = R.drawable.back,
-                        contentDescription = "Back",
-                        onClick = onBack,
-                    )
-                }
-            }
-
-            val name = exportedVideo.name
-            val start = exportedVideo.startDate.format(StandardDateTimeFormatter.date)
-            val end = exportedVideo.endDate.format(StandardDateTimeFormatter.date)
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(horizontal = 8.dp)
-            ) {
-                if (name != null) {
-                    Text(
-                        text = name,
-                        color = Color.White,
-                        textAlign = TextAlign.Center,
-                        fontSize = Typography.Size.medium,
-                    )
-                    Text(
-                        text = "$start to $end",
-                        color = Color.White.copy(alpha = 0.7f),
-                        textAlign = TextAlign.Center,
-                        fontSize = Typography.Size.extraSmall,
-                    )
-                } else {
-                    Text(
-                        text = "$start to $end",
-                        color = Color.White,
-                        textAlign = TextAlign.Center,
-                        fontSize = Typography.Size.medium,
-                    )
-                }
-            }
-
-            Box(modifier = Modifier.size(50.dp))
-        }
-    }
-}
-
-@Composable
-private fun ToolbarIconButton(
-    iconRes: Int,
-    contentDescription: String?,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        contentAlignment = Alignment.Center,
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .minimumInteractiveComponentSize()
-            .clip(CircleShape)
-            .clickable(onClick = onClick)
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
-        Image(
-            painter = painterResource(iconRes),
-            contentDescription = contentDescription,
-            colorFilter = ColorFilter.tint(Color.White),
-            modifier = Modifier.size(24.dp),
-        )
+        Box(modifier = Modifier.size(50.dp)) {
+            if (canGoBack) {
+                GlassIconButton(
+                    iconRes = R.drawable.back,
+                    contentDescription = "Back",
+                    onClick = onBack,
+                )
+            }
+        }
+
+        val name = exportedVideo.name
+        val start = exportedVideo.startDate.format(StandardDateTimeFormatter.date)
+        val end = exportedVideo.endDate.format(StandardDateTimeFormatter.date)
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 8.dp)
+        ) {
+            if (name != null) {
+                Text(
+                    text = name,
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    fontSize = Typography.Size.medium,
+                )
+                Text(
+                    text = "$start to $end",
+                    color = Color.White.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center,
+                    fontSize = Typography.Size.extraSmall,
+                )
+            } else {
+                Text(
+                    text = "$start to $end",
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    fontSize = Typography.Size.medium,
+                )
+            }
+        }
+
+        Box(modifier = Modifier.size(50.dp))
     }
 }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/check/CheckVideoPageContent.kt
@@ -1,32 +1,25 @@
 package com.lukeneedham.videodiary.ui.feature.record.check
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lukeneedham.videodiary.R
 import com.lukeneedham.videodiary.domain.model.Video
 import com.lukeneedham.videodiary.ui.feature.common.glass.GlassAcceptButton
 import com.lukeneedham.videodiary.ui.feature.common.glass.GlassIconButton
-import com.lukeneedham.videodiary.ui.feature.common.glass.TopScrim
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayer
 import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoPlayerController
+import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoToolbarLayout
 
 @Composable
 fun CheckVideoPageContent(
@@ -41,84 +34,70 @@ fun CheckVideoPageContent(
             playingVideo = video
         }
     }
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(videoAspectRatio)
-        ) {
-            VideoPlayer(
-                video = video,
-                aspectRatio = videoAspectRatio,
-                controller = videoPlayerController,
-                modifier = Modifier.fillMaxSize(),
-            )
-
-            TopScrim(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .height(140.dp)
-            )
-
+    VideoToolbarLayout(
+        videoAspectRatio = videoAspectRatio,
+        topOverlay = {
             GlassIconButton(
                 iconRes = R.drawable.close,
                 contentDescription = "Cancel",
                 onClick = onCancelClick,
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .safeDrawingPadding()
                     .padding(16.dp)
             )
-        }
-
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .background(Color.Black)
-                .navigationBarsPadding()
-                .padding(horizontal = 16.dp)
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.align(Alignment.CenterStart)
+        },
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
             ) {
-                val muteIcon =
-                    if (videoPlayerController.isVolumeOn) R.drawable.volume_on else R.drawable.volume_off
-                GlassIconButton(
-                    iconRes = muteIcon,
-                    contentDescription = "Toggle sound",
-                    onClick = { videoPlayerController.toggleVolumeOn() },
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.align(Alignment.CenterStart)
+                ) {
+                    val muteIcon =
+                        if (videoPlayerController.isVolumeOn) R.drawable.volume_on else R.drawable.volume_off
+                    GlassIconButton(
+                        iconRes = muteIcon,
+                        contentDescription = "Toggle sound",
+                        onClick = { videoPlayerController.toggleVolumeOn() },
+                    )
+
+                    val isPlaying = !videoPlayerController.isTogglePaused
+                    val playIcon = if (isPlaying) R.drawable.pause else R.drawable.play
+                    GlassIconButton(
+                        iconRes = playIcon,
+                        contentDescription = "Play/pause",
+                        onClick = { videoPlayerController.toggleIsPlaying() },
+                    )
+                }
+
+                GlassAcceptButton(
+                    onClick = onAccepted,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(vertical = 10.dp)
+                        .fillMaxHeight()
+                        .aspectRatio(1f)
                 )
 
-                val isPlaying = !videoPlayerController.isTogglePaused
-                val playIcon = if (isPlaying) R.drawable.pause else R.drawable.play
                 GlassIconButton(
-                    iconRes = playIcon,
-                    contentDescription = "Play/pause",
-                    onClick = { videoPlayerController.toggleIsPlaying() },
+                    iconRes = R.drawable.retake,
+                    contentDescription = "Retake",
+                    onClick = onRetakeClick,
+                    modifier = Modifier.align(Alignment.CenterEnd)
                 )
             }
-
-            GlassAcceptButton(
-                onClick = onAccepted,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(vertical = 10.dp)
-                    .fillMaxHeight()
-                    .aspectRatio(1f)
-            )
-
-            GlassIconButton(
-                iconRes = R.drawable.retake,
-                contentDescription = "Retake",
-                onClick = onRetakeClick,
-                modifier = Modifier.align(Alignment.CenterEnd)
-            )
-        }
+        },
+    ) { aspectRatio ->
+        VideoPlayer(
+            video = video,
+            aspectRatio = aspectRatio,
+            controller = videoPlayerController,
+            modifier = Modifier.fillMaxSize(),
+        )
     }
 }
 

--- a/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
+++ b/app/src/main/java/com/lukeneedham/videodiary/ui/feature/record/film/RecordVideoPageContent.kt
@@ -8,19 +8,12 @@ import androidx.camera.video.Quality
 import androidx.camera.video.QualitySelector
 import androidx.camera.video.Recorder
 import androidx.camera.video.VideoCapture
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.lifecycle.Observer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -33,7 +26,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -42,7 +34,7 @@ import com.lukeneedham.videodiary.domain.util.logger.Logger
 import com.lukeneedham.videodiary.ui.feature.common.camera.CameraInput
 import com.lukeneedham.videodiary.ui.feature.common.glass.GlassIconButton
 import com.lukeneedham.videodiary.ui.feature.common.glass.GlassRecordButton
-import com.lukeneedham.videodiary.ui.feature.common.glass.TopScrim
+import com.lukeneedham.videodiary.ui.feature.common.videoplayer.VideoToolbarLayout
 import com.lukeneedham.videodiary.ui.feature.record.film.component.CameraControlSlider
 import com.lukeneedham.videodiary.ui.feature.record.film.component.RecordingCountdownButton
 
@@ -137,116 +129,102 @@ fun RecordVideoPageContent(
         }
     }
 
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(videoAspectRatio)
-        ) {
-            CameraInput(
-                currentResolution = resolution,
-                videoCapture = videoCapture,
-                onResolutionLoaded = { resolution, isMissing, loadedRotation ->
-                    if (isMissing) {
-                        Logger.error("No camera feed available for resolution: $resolution")
-                    }
-                },
-                canZoom = true,
-                onCameraReady = { camera = it },
-                modifier = Modifier.fillMaxSize()
-            )
-
-            TopScrim(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .height(140.dp)
-            )
-
+    VideoToolbarLayout(
+        videoAspectRatio = videoAspectRatio,
+        topOverlay = {
             GlassIconButton(
                 iconRes = R.drawable.close,
                 contentDescription = "Close",
                 onClick = onBack,
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .safeDrawingPadding()
                     .padding(16.dp)
             )
-        }
+        },
+        bottomBar = {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 8.dp)
+            ) {
+                val cam = camera
+                val exposureState = cam?.cameraInfo?.exposureState
+                val exposureRange = exposureState?.exposureCompensationRange
+                val supportsExposure = exposureRange != null
+                        && exposureRange.lower < exposureRange.upper
 
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .background(Color.Black)
-                .navigationBarsPadding()
-                .padding(horizontal = 8.dp)
-        ) {
-            val cam = camera
-            val exposureState = cam?.cameraInfo?.exposureState
-            val exposureRange = exposureState?.exposureCompensationRange
-            val supportsExposure = exposureRange != null
-                    && exposureRange.lower < exposureRange.upper
+                if (supportsExposure && !brightnessValue.isNaN() && cam != null && exposureRange != null) {
+                    CameraControlSlider(
+                        value = brightnessValue,
+                        onValueChange = { newValue ->
+                            brightnessValue = newValue
+                            val index = exposureRange.lower +
+                                    ((exposureRange.upper - exposureRange.lower) * newValue).toInt()
+                            cam.cameraControl.setExposureCompensationIndex(index)
+                        },
+                        iconRes = R.drawable.brightness,
+                        contentDescription = "Brightness",
+                        modifier = Modifier.weight(1f),
+                    )
+                } else {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
 
-            if (supportsExposure && !brightnessValue.isNaN() && cam != null && exposureRange != null) {
-                CameraControlSlider(
-                    value = brightnessValue,
-                    onValueChange = { newValue ->
-                        brightnessValue = newValue
-                        val index = exposureRange.lower +
-                                ((exposureRange.upper - exposureRange.lower) * newValue).toInt()
-                        cam.cameraControl.setExposureCompensationIndex(index)
-                    },
-                    iconRes = R.drawable.brightness,
-                    contentDescription = "Brightness",
-                    modifier = Modifier.weight(1f),
-                )
-            } else {
-                Spacer(modifier = Modifier.weight(1f))
+                val centerButtonModifier = Modifier
+                    .padding(vertical = 10.dp, horizontal = 5.dp)
+                    .fillMaxHeight()
+                    .aspectRatio(1f)
+                if (currentState is RecordingState.Recording) {
+                    val remainingSeconds = ((videoDurationMillis - currentState.duration.inWholeMilliseconds) / 1000.0)
+                        .coerceAtLeast(0.0)
+                    val remainingText = "%.1f".format(remainingSeconds)
+                    RecordingCountdownButton(
+                        remainingText = remainingText,
+                        onClick = {
+                            videoRecorder.cancelRecording()
+                            state = RecordingState.Ready
+                        },
+                        modifier = centerButtonModifier,
+                    )
+                } else {
+                    GlassRecordButton(
+                        isRecording = false,
+                        enabled = currentState == RecordingState.Ready,
+                        onClick = { record() },
+                        modifier = centerButtonModifier,
+                    )
+                }
+
+                if (cam != null && !zoomValue.isNaN()) {
+                    CameraControlSlider(
+                        value = zoomValue,
+                        onValueChange = { newValue ->
+                            zoomValue = newValue
+                            cam.cameraControl.setLinearZoom(newValue)
+                        },
+                        iconRes = R.drawable.zoom,
+                        contentDescription = "Zoom",
+                        modifier = Modifier.weight(1f),
+                    )
+                } else {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
             }
-
-            val centerButtonModifier = Modifier
-                 .padding(vertical = 10.dp, horizontal = 5.dp)
-                .fillMaxHeight()
-                .aspectRatio(1f)
-            if (currentState is RecordingState.Recording) {
-                val remainingSeconds = ((videoDurationMillis - currentState.duration.inWholeMilliseconds) / 1000.0)
-                    .coerceAtLeast(0.0)
-                val remainingText = "%.1f".format(remainingSeconds)
-                RecordingCountdownButton(
-                    remainingText = remainingText,
-                    onClick = {
-                        videoRecorder.cancelRecording()
-                        state = RecordingState.Ready
-                    },
-                    modifier = centerButtonModifier,
-                )
-            } else {
-                GlassRecordButton(
-                    isRecording = false,
-                    enabled = currentState == RecordingState.Ready,
-                    onClick = { record() },
-                    modifier = centerButtonModifier,
-                )
-            }
-
-            if (cam != null && !zoomValue.isNaN()) {
-                CameraControlSlider(
-                    value = zoomValue,
-                    onValueChange = { newValue ->
-                        zoomValue = newValue
-                        cam.cameraControl.setLinearZoom(newValue)
-                    },
-                    iconRes = R.drawable.zoom,
-                    contentDescription = "Zoom",
-                    modifier = Modifier.weight(1f),
-                )
-            } else {
-                Spacer(modifier = Modifier.weight(1f))
-            }
-        }
+        },
+    ) {
+        CameraInput(
+            currentResolution = resolution,
+            videoCapture = videoCapture,
+            onResolutionLoaded = { resolution, isMissing, loadedRotation ->
+                if (isMissing) {
+                    Logger.error("No camera feed available for resolution: $resolution")
+                }
+            },
+            canZoom = true,
+            onCameraReady = { camera = it },
+            modifier = Modifier.fillMaxSize()
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Flipped `VideoToolbarLayout` so the video now fills the top of the screen, with a solid black toolbar at the bottom (previously it was the reverse: black toolbar on top, video below).
- The buttons that used to live in the solid top toolbar (calendar menu/date-nav/jump-to-today, export view back button + title) are now `GlassIconButton`s floating over the top edge of the video, with a `TopScrim` behind them for legibility.
- The buttons that used to float glassy over the bottom of the video (mute/play/retake/share/delete) now live in the solid black bottom bar instead.
- On the calendar screen, the bottom bar's controls are hoisted out of the per-page pager content (mirroring how the top bar already tracked the pager's "current day") so they render once, outside `HorizontalPager`, driven by the current day.

## Test plan
- [x] `./gradlew compileDebugKotlin`
- [x] `./gradlew assembleDebug`
- [ ] Manually verify calendar and export-diary-view screens in the app (menu/date-nav/jump-to-today float glassy over the video top; mute/play/retake/share/delete sit in the black bar at the bottom)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XerikjsNCJQyD7b5WxrUMJ)_